### PR TITLE
fix: Remove back button from Quests and Assets screens

### DIFF
--- a/app/(stack)/projects/[projectId]/quests/[questId]/assets/[assetId].tsx
+++ b/app/(stack)/projects/[projectId]/quests/[questId]/assets/[assetId].tsx
@@ -393,12 +393,6 @@ export default function AssetView() {
         <SafeAreaView style={styles.safeArea} edges={['top', 'left', 'right']}>
           <View style={styles.content}>
             <Text style={styles.title}>{asset?.name}</Text>
-            <TouchableOpacity
-              onPress={() => router.back()}
-              style={sharedStyles.backButton}
-            >
-              <Ionicons name="arrow-back" size={24} color={colors.text} />
-            </TouchableOpacity>
             <View style={styles.tabBar}>
               <TouchableOpacity
                 style={[

--- a/app/(stack)/projects/[projectId]/quests/[questId]/assets/index.tsx
+++ b/app/(stack)/projects/[projectId]/quests/[questId]/assets/index.tsx
@@ -309,12 +309,6 @@ export default function Assets() {
           style={[sharedStyles.container, { backgroundColor: 'transparent' }]}
         >
           <View style={styles.headerContainer}>
-            <TouchableOpacity
-              onPress={() => router.back()}
-              style={styles.backButton}
-            >
-              <Ionicons name="arrow-back" size={24} color={colors.text} />
-            </TouchableOpacity>
             <View style={styles.searchContainer}>
               <Ionicons
                 name="search"
@@ -443,8 +437,5 @@ const styles = StyleSheet.create({
     borderRadius: borderRadius.small,
     paddingHorizontal: spacing.small,
     marginRight: spacing.small
-  },
-  backButton: {
-    padding: spacing.small
   }
 });

--- a/app/(stack)/projects/[projectId]/quests/index.tsx
+++ b/app/(stack)/projects/[projectId]/quests/index.tsx
@@ -288,12 +288,6 @@ export default function Quests() {
           style={[sharedStyles.container, { backgroundColor: 'transparent' }]}
         >
           <View style={styles.headerContainer}>
-            <TouchableOpacity
-              onPress={() => router.back()}
-              style={styles.backButton}
-            >
-              <Ionicons name="arrow-back" size={24} color={colors.text} />
-            </TouchableOpacity>
             <Text style={styles.title}>
               {projectName} {t('quests')}
             </Text>
@@ -425,14 +419,10 @@ const styles = StyleSheet.create({
     padding: spacing.small,
     alignSelf: 'flex-end'
   },
-  backButton: {
-    padding: spacing.small
-  },
   title: {
     fontSize: fontSizes.xxlarge,
     fontWeight: 'bold',
     color: colors.text,
-    marginLeft: spacing.medium,
     flex: 1,
     textAlign: 'center'
   }


### PR DESCRIPTION
- Remove back button from Quests, Assets, and AssetView screens
- Adjust title positioning and styling
- Simplify header and navigation layout