### PR TITLE
chore: remove path trigger for sync rules in deploy workflow

### DIFF
--- a/.github/workflows/deploy-sync-rules.yml
+++ b/.github/workflows/deploy-sync-rules.yml
@@ -3,7 +3,6 @@ name: Deploy Sync Rules
 on:
   push:
     branches: ['dev']
-    paths: ['supabase/config/sync-rules.yml'] # Only trigger when sync rules file is changed
 
 jobs:
   deploy-sync-rules:


### PR DESCRIPTION
- Eliminated the specific path trigger for 'supabase/config/sync-rules.yml' in the deploy-sync-rules.yml workflow to allow broader deployment on push to the 'dev' branch.