### PR TITLE
chore: add concurrency settings to sync rules workflows

### DIFF
--- a/.github/workflows/deploy-sync-rules.yml
+++ b/.github/workflows/deploy-sync-rules.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: ['dev']
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   deploy-sync-rules:
     runs-on: ubuntu-latest
@@ -19,4 +23,4 @@ jobs:
           ORG_ID: ${{ secrets.POWERSYNC_ORG }}
           PROJECT_ID: ${{ secrets.POWERSYNC_PROJECT }}
           INSTANCE_ID: ${{ secrets.POWERSYNC_PROD_INSTANCE }}
-        run: npx powersync sync-rules deploy ./supabase/config/sync-rules.yml
+        run: npx powersync instance sync-rules deploy ./supabase/config/sync-rules.yml

--- a/.github/workflows/validate-sync-rules.yml
+++ b/.github/workflows/validate-sync-rules.yml
@@ -8,6 +8,10 @@ on:
     branches: ['dev']
     paths: ['supabase/config/sync-rules.yml']
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   validate-sync-rules:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Introduced concurrency settings in deploy-sync-rules.yml and validate-sync-rules.yml to manage workflow execution and prevent overlapping runs on non-main branches.