### PR TITLE
Fix app drawer type errors

### DIFF
--- a/components/AppDrawer.tsx
+++ b/components/AppDrawer.tsx
@@ -429,20 +429,12 @@ export default function AppDrawer({
       finalAlertTitle = t('backupCompleteTitle');
       console.log('audioResult', audioResult);
       // Reuse restore-style message structure if available
-      const copied = audioResult.copied;
-      const skippedExists = audioResult.alreadyExists;
+      const copied = audioResult.count;
       const skippedErrors = audioResult.errors.length;
       let msg = t('restoreCompleteBase', {
         audioCopied: String(copied),
         audioSkippedDueToError: String(skippedErrors)
       });
-      if (skippedExists > 0) {
-        msg +=
-          ' ' +
-          t('restoreSkippedLocallyPart', {
-            audioSkippedLocally: String(skippedExists)
-          });
-      }
       finalAlertMessage = msg;
     } catch (error: unknown) {
       // Handle errors from any awaited step above


### PR DESCRIPTION
Fix type errors in `AppDrawer.tsx` by using `count` instead of `copied` and removing the non-existent `alreadyExists` property.

---
<a href="https://cursor.com/background-agent?bcId=bc-1115c6d3-be9c-41d8-bc17-88d9028b09a0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1115c6d3-be9c-41d8-bc17-88d9028b09a0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

