### PR TITLE
fix: ios all glory to our Lord Jesus Christ and God our Father (thanks Ryder)

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -33,9 +33,6 @@ export default ({ config }: ConfigContext): ExpoConfig =>
         bundleIdentifier: uniqueIdentifier,
         config: {
           usesNonExemptEncryption: false
-        },
-        entitlements: {
-          'com.apple.developer.networking.wifi-info': true
         }
       },
       android: {


### PR DESCRIPTION
- Deleted the 'entitlements' section related to Wi-Fi info from the app.config.ts file, streamlining the configuration.