### PR TITLE
chore: update deployment workflows to include environment specifications

### DIFF
--- a/.eas/workflows/deploy-to-preview.yml
+++ b/.eas/workflows/deploy-to-preview.yml
@@ -13,6 +13,7 @@ jobs:
     name: Check for existing android build
     needs: [fingerprint]
     type: get-build
+    environment: preview
     params:
       fingerprint_hash: ${{ needs.fingerprint.outputs.android_fingerprint_hash }}
       profile: preview
@@ -20,6 +21,7 @@ jobs:
     name: Check for existing ios build
     needs: [fingerprint]
     type: get-build
+    environment: preview
     params:
       fingerprint_hash: ${{ needs.fingerprint.outputs.ios_fingerprint_hash }}
       profile: preview
@@ -45,12 +47,14 @@ jobs:
   #   name: Submit Android Build
   #   needs: [build_android]
   #   type: submit
+  #   environment: preview
   #   params:
   #     build_id: ${{ needs.build_android.outputs.build_id }}
   # submit_ios_build:
   #   name: Submit iOS Build
   #   needs: [build_ios]
   #   type: submit
+  #   environment: preview
   #   params:
   #     build_id: ${{ needs.build_ios.outputs.build_id }}
   publish_android_update:

--- a/.eas/workflows/deploy-to-production.yml
+++ b/.eas/workflows/deploy-to-production.yml
@@ -13,6 +13,7 @@ jobs:
     name: Check for existing android build
     needs: [fingerprint]
     type: get-build
+    environment: production
     params:
       fingerprint_hash: ${{ needs.fingerprint.outputs.android_fingerprint_hash }}
       profile: production
@@ -20,6 +21,7 @@ jobs:
     name: Check for existing ios build
     needs: [fingerprint]
     type: get-build
+    environment: production
     params:
       fingerprint_hash: ${{ needs.fingerprint.outputs.ios_fingerprint_hash }}
       profile: production
@@ -45,12 +47,14 @@ jobs:
     name: Submit Android Build
     needs: [build_android]
     type: submit
+    environment: production
     params:
       build_id: ${{ needs.build_android.outputs.build_id }}
   submit_ios_build:
     name: Submit iOS Build
     needs: [build_ios]
     type: submit
+    environment: production
     params:
       build_id: ${{ needs.build_ios.outputs.build_id }}
   publish_android_update:


### PR DESCRIPTION
- Added 'environment: preview' to the deploy-to-preview.yml workflow for Android and iOS build checks.
- Added 'environment: production' to the deploy-to-production.yml workflow for Android and iOS build checks and submissions.