### PR TITLE
Start environment and get ngrok url

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "langquest",
-  "version": "1.3.2",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "langquest",
-      "version": "1.3.2",
+      "version": "2.0.0",
       "dependencies": {
         "@azure/core-asynciterator-polyfill": "^1.0.2",
         "@expo/vector-icons": "^14.0.2",


### PR DESCRIPTION
Bump project version from 1.3.2 to 2.0.0.

This version bump occurred as a result of setting up and running the local environment, which involved installing dependencies and configuring services like Docker, ngrok, Supabase, and PowerSync.

---
<a href="https://cursor.com/background-agent?bcId=bc-ef7fc5f1-ebf9-4138-b4e2-d9fb764c9003"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ef7fc5f1-ebf9-4138-b4e2-d9fb764c9003"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

