### PR TITLE
fix dark mode splash screen - All glory goes to God our Father and the Lord Jesus Christ and the Holy Spirit.

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -57,14 +57,6 @@ export default ({ config }: ConfigContext): ExpoConfig =>
       icon: iconLight,
       scheme: getScheme(appVariant),
       userInterfaceStyle: 'automatic',
-      splash: {
-        image: iconLight,
-        backgroundColor: '#f5f5ff',
-        dark: {
-          image: iconDark,
-          backgroundColor: '#131320'
-        }
-      },
       ios: {
         icon: {
           light: iconLight,


### PR DESCRIPTION
- Introduced configuration for expo-splash-screen with light and dark mode settings.
- Set splash screen image and background colors for improved user experience.