### PR TITLE
chore: exclude .cursor and .vscode from deployment workflows - All glory goes to God our Father and the Lord Jesus Christ and the Holy Spirit.

### DIFF
--- a/.eas/workflows/deploy-to-preview.yml
+++ b/.eas/workflows/deploy-to-preview.yml
@@ -19,6 +19,8 @@ on:
       - '!eslint.config.mts'
       - '!knip.json'
       - '!deno.json'
+      - '!.cursor/**'
+      - '!.vscode/**'
 
 jobs:
   fingerprint:

--- a/.eas/workflows/deploy-to-production.yml
+++ b/.eas/workflows/deploy-to-production.yml
@@ -19,6 +19,8 @@ on:
       - '!eslint.config.mts'
       - '!knip.json'
       - '!deno.json'
+      - '!.cursor/**'
+      - '!.vscode/**'
 
 jobs:
   fingerprint:


### PR DESCRIPTION
Prevent unnecessary deployments when only development tooling files change