### PR TITLE
Remove reopened github events - All glory goes to God our Father and the Lord Jesus Christ and the Holy Spirit.

### DIFF
--- a/.github/workflows/validate-migrations.yml
+++ b/.github/workflows/validate-migrations.yml
@@ -2,7 +2,7 @@ name: Validate Migration History
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/validate-sync-rules-pr.yml
+++ b/.github/workflows/validate-sync-rules-pr.yml
@@ -2,7 +2,7 @@ name: Validate Sync Rules on PR
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Remove `reopened` event from pull request workflows to prevent redundant job runs.

---
<a href="https://cursor.com/background-agent?bcId=bc-041d4de8-d79f-4700-b834-5f8dd764e04f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-041d4de8-d79f-4700-b834-5f8dd764e04f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

