### PR TITLE
Backfill download_profiles for existing profile_project_link records

### DIFF
--- a/supabase/migrations/20251210030242_backfill_profile_project_link_download_profiles.sql
+++ b/supabase/migrations/20251210030242_backfill_profile_project_link_download_profiles.sql
@@ -1,0 +1,34 @@
+-- Migration: Backfill download_profiles for existing profile_project_link records
+-- Purpose:
+-- - Populate download_profiles for existing active members with OTHER active members' profile_ids
+-- - Set download_profiles to null for inactive members
+-- - Ensures existing records match the behavior of the trigger functions
+-- - Uses the existing normalize_download_profiles function for consistency
+
+-- Increase timeout for long-running migration (may affect many rows)
+set statement_timeout = '30min';
+
+-- Backfill download_profiles for active members
+-- For each active record, populate with all OTHER active members' profile_ids in the same project
+-- This ensures all active records have the correct download_profiles, even if they were set incorrectly before
+update public.profile_project_link ppl
+set download_profiles = public.normalize_download_profiles(
+    (
+        select coalesce(array_agg(other_ppl.profile_id), '{}')
+        from public.profile_project_link other_ppl
+        where other_ppl.project_id = ppl.project_id
+          and other_ppl.active = true
+          and other_ppl.profile_id != ppl.profile_id
+    )
+)
+where ppl.active = true;
+
+-- Set download_profiles to null for inactive members
+-- Inactive members don't need to sync other members' profiles
+update public.profile_project_link
+set download_profiles = null
+where active is distinct from true
+  and download_profiles is not null;
+
+-- Reset timeout to default
+reset statement_timeout;


### PR DESCRIPTION
## Summary
This migration backfills the `download_profiles` column for existing `profile_project_link` records to ensure they match the behavior of the trigger functions added in the previous migration.

## Changes
- Populates `download_profiles` for active members with other active members' `profile_id`s in the same project
- Sets `download_profiles` to `null` for inactive members
- Uses the existing `normalize_download_profiles` function for consistency
- Includes a 30-minute statement timeout for long-running operations

## Testing
- ✅ Migration tested against local Supabase instance
- ✅ Successfully updated 4 active records
- ✅ Idempotent (safe to run multiple times)

## Related
Follows up on migration `20251205140359_add_download_profiles_to_profile_project_link.sql`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed data consistency for profile and project member relationships through a database migration that properly backfills profile information for existing project associations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->