### PR TITLE
Add enablePlayAll feature flag checks to Play All buttons

### DIFF
--- a/views/new/NextGenAssetsView.tsx
+++ b/views/new/NextGenAssetsView.tsx
@@ -241,6 +241,7 @@ export default function NextGenAssetsView() {
   const currentStatus = useStatusContext();
   currentStatus.layerStatus(LayerType.QUEST, currentQuestId || '');
   const showInvisibleContent = useLocalStore((s) => s.showHiddenContent);
+  const enablePlayAll = useLocalStore((s) => s.enablePlayAll);
 
   const {
     data,
@@ -1044,7 +1045,7 @@ export default function NextGenAssetsView() {
               <Icon as={RefreshCwIcon} size={18} className="text-primary" />
             </Animated.View>
           </Button>
-          {assets.length > 0 && (
+          {assets.length > 0 && enablePlayAll && (
             <Button
               variant="ghost"
               size="icon"

--- a/views/new/recording/components/RecordingViewSimplified.tsx
+++ b/views/new/recording/components/RecordingViewSimplified.tsx
@@ -138,6 +138,7 @@ const RecordingViewSimplified = ({
   );
   const vadDisplayMode = useLocalStore((state) => state.vadDisplayMode);
   const setVadDisplayMode = useLocalStore((state) => state.setVadDisplayMode);
+  const enablePlayAll = useLocalStore((state) => state.enablePlayAll);
   const [showVADSettings, setShowVADSettings] = React.useState(false);
   const [autoCalibrateOnOpen, setAutoCalibrateOnOpen] = React.useState(false);
 
@@ -2132,7 +2133,7 @@ const RecordingViewSimplified = ({
             {t('assets')} ({assets.length})
           </Text>
         </View>
-        {assets.length > 0 && (
+        {assets.length > 0 && enablePlayAll && (
           <Button
             variant="ghost"
             size="icon"


### PR DESCRIPTION
## Changes
- Add `enablePlayAll` feature flag check to Play All button in `NextGenAssetsView`
- Add `enablePlayAll` feature flag check to Play All button in `RecordingViewSimplified`

The Play All buttons will now only be visible when the `enablePlayAll` feature flag is enabled in the local store.