### PR TITLE
fix(profile): fix disabled submit button when password fields are filled

### DIFF
--- a/views/ProfileView.tsx
+++ b/views/ProfileView.tsx
@@ -82,7 +82,13 @@ export default function ProfileView() {
 
   const formSchema = z
     .object({
-      selectedLanguoidId: z.uuid(t('selectLanguage')),
+      selectedLanguoidId: z
+        .string()
+        .refine(
+          (val) => !val || z.uuid().safeParse(val).success,
+          t('selectLanguage')
+        )
+        .optional(),
       currentPassword: z.string().trim().optional(),
       newPassword: z.string().trim().optional(),
       confirmPassword: z.string().trim().optional(),
@@ -142,7 +148,9 @@ export default function ProfileView() {
 
       const updatedUser = await profileService.updateProfile({
         id: currentUser.id,
-        ui_languoid_id: data.selectedLanguoidId,
+        ...(data.selectedLanguoidId
+          ? { ui_languoid_id: data.selectedLanguoidId }
+          : {}),
         ...(isOnline && data.newPassword
           ? { password: data.newPassword.trim() }
           : {}),


### PR DESCRIPTION
The button was disabled because selectedLanguoidId could be an empty string, which failed UUID validation. Updated schema to accept empty strings or valid UUIDs, and only include ui_languoid_id in updates when a value is provided.