### PR TITLE
Community slider integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "langquest",
-  "version": "2.0.8",
+  "version": "2.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "langquest",
-      "version": "2.0.8",
+      "version": "2.0.11",
       "hasInstallScript": true,
       "dependencies": {
         "@azure/core-asynciterator-polyfill": "^1.0.2",
@@ -36,7 +36,6 @@
         "@rn-primitives/portal": "^1.3.0",
         "@rn-primitives/progress": "^1.2.0",
         "@rn-primitives/select": "^1.1.0",
-        "@rn-primitives/slider": "1.2.0",
         "@rn-primitives/slot": "^1.2.0",
         "@rn-primitives/switch": "^1.2.0",
         "@rn-primitives/tabs": "^1.2.0",
@@ -7201,39 +7200,6 @@
         }
       }
     },
-    "node_modules/@radix-ui/react-slider": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slider/-/react-slider-1.3.6.tgz",
-      "integrity": "sha512-JPYb1GuM1bxfjMRlNLE+BcmBC8onfCi60Blk7OBqi2MLTFdS+8401U4uFjnwkOr49BLmXxLC6JHkvAsx5OJvHw==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/number": "1.1.1",
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-collection": "1.1.7",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-direction": "1.1.1",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-controllable-state": "1.2.2",
-        "@radix-ui/react-use-layout-effect": "1.1.1",
-        "@radix-ui/react-use-previous": "1.1.1",
-        "@radix-ui/react-use-size": "1.1.1"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@radix-ui/react-slot": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.0.tgz",
@@ -8505,30 +8471,6 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@rn-primitives/slider": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@rn-primitives/slider/-/slider-1.2.0.tgz",
-      "integrity": "sha512-JRxTQelfEdG7tWA+7v5YY/9hUeZXe99BrfRH4b/kUbdMdzMp+MEEvJ6y1iqUlNIys5B6uuTWLnFjI8IhG/MkXw==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-slider": "^1.3.5",
-        "@rn-primitives/slot": "1.2.0",
-        "@rn-primitives/types": "1.2.0"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-native": "*",
-        "react-native-web": "*"
-      },
-      "peerDependenciesMeta": {
-        "react-native": {
-          "optional": true
-        },
-        "react-native-web": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
     "@rn-primitives/portal": "^1.3.0",
     "@rn-primitives/progress": "^1.2.0",
     "@rn-primitives/select": "^1.1.0",
-    "@rn-primitives/slider": "1.2.0",
     "@rn-primitives/slot": "^1.2.0",
     "@rn-primitives/switch": "^1.2.0",
     "@rn-primitives/tabs": "^1.2.0",


### PR DESCRIPTION
Replace `@rn-primitives/slider` with `@react-native-community/slider` to enable gesture handling while preserving existing NativeWind styling.

The previous `components/ui/slider.tsx` was a custom Reanimated + Gesture Handler implementation, not fully utilizing `@rn-primitives/slider`. This PR updates the custom wrapper to use `@react-native-community/slider` for reliable gesture handling on both native and web, simplifying the component while maintaining its visual appearance.

---
<a href="https://cursor.com/background-agent?bcId=bc-10e79f2f-e8c7-4c54-8f3d-3da86c9d0d16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-10e79f2f-e8c7-4c54-8f3d-3da86c9d0d16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

