### PR TITLE
PowerSync view cleanup

### DIFF
--- a/db/powersync/system.ts
+++ b/db/powersync/system.ts
@@ -769,6 +769,50 @@ export class System {
           if (row.name) existingByName.set(row.name, normalize(row.sql));
         }
       }
+
+      // CLEANUP: Find and remove orphaned views that are no longer in drizzleSchema
+      // This handles cases where tables are renamed or removed from the schema
+      console.log('[createUnionViews] Checking for orphaned views...');
+      const plannedViewNames = new Set(plannedStatements.map((p) => p.view));
+      
+      // Query all existing union views (those that have corresponding _synced and _local tables)
+      // We identify union views by checking if they have a corresponding synced table
+      const allExistingViews = await this.powersync.getAll<{ name: string }>(
+        `SELECT DISTINCT v.name 
+         FROM sqlite_master v
+         WHERE v.type = 'view'
+         AND EXISTS (
+           SELECT 1 FROM sqlite_master t 
+           WHERE t.type = 'table' 
+           AND t.name = v.name || '_synced'
+         )`
+      );
+      
+      const orphanedViews = allExistingViews
+        .filter((v) => !plannedViewNames.has(v.name))
+        .map((v) => v.name);
+      
+      if (orphanedViews.length > 0) {
+        console.log(
+          `[createUnionViews] Found ${orphanedViews.length} orphaned view(s): ${orphanedViews.join(', ')}`
+        );
+        
+        // Drop orphaned views
+        for (const viewName of orphanedViews) {
+          try {
+            await this.powersync.execute(`DROP VIEW IF EXISTS "${viewName}"`);
+            console.log(`[createUnionViews] ✓ Dropped orphaned view: ${viewName}`);
+          } catch (error) {
+            console.warn(
+              `[createUnionViews] Failed to drop orphaned view ${viewName}:`,
+              error
+            );
+          }
+        }
+      } else {
+        console.log('[createUnionViews] No orphaned views found');
+      }
+
       await this.powersync.writeTransaction(async (tx) => {
         // Compare with existing view SQL and apply only when different
         for (const { view, dropSql, createSql } of plannedStatements) {


### PR DESCRIPTION
Add cleanup logic to `createUnionViews()` to automatically remove orphaned views, preventing accumulation of obsolete views after schema changes.

Previously, `createUnionViews()` only managed views defined in `drizzleSchema`, leading to orphaned views remaining in the database when tables were renamed or removed from the schema. This change ensures that views no longer present in `drizzleSchema` are automatically dropped.

---
<a href="https://cursor.com/background-agent?bcId=bc-23b40e41-50e6-4f1e-b6d7-5acbe0c43fa3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-23b40e41-50e6-4f1e-b6d7-5acbe0c43fa3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

