### PR TITLE
Bible content download sync

### DIFF
--- a/components/BibleReaderContent.tsx
+++ b/components/BibleReaderContent.tsx
@@ -400,13 +400,7 @@ function formatBibleLabel(bible: BibleBrainBible): string {
   return bible.vname || bible.name;
 }
 
-// --- Translation download button for new translations in FIA drawer ---
-
-type TranslationDownloadState =
-  | { status: 'idle' }
-  | { status: 'downloading'; label: string }
-  | { status: 'done' }
-  | { status: 'error'; message: string };
+// --- Add/remove translation from download list (FIA drawer) ---
 
 function parseFiaVerseRange(vr: string) {
   const m = vr.match(/^(\d+):(\d+)[a-z]?-(?:(\d+):)?(\d+)[a-z]?$/);
@@ -419,13 +413,17 @@ function parseFiaVerseRange(vr: string) {
   };
 }
 
-function TranslationDownloadButton({
+type DlBtnState = 'idle' | 'downloading' | 'done' | 'error';
+
+function TranslationDownloadToggle({
   bible,
+  projectId,
   fiaBookId,
   verseRange,
   audioData
 }: {
   bible: BibleBrainBible;
+  projectId?: string;
   fiaBookId?: string;
   verseRange?: string;
   audioData?: BibleBrainAudioChapter[];
@@ -433,9 +431,14 @@ function TranslationDownloadButton({
   const { session } = useAuth();
   const isOnline = useNetworkStatus();
   const supabaseUrl = process.env.EXPO_PUBLIC_SUPABASE_URL;
-  const [state, setState] = useState<TranslationDownloadState>({
-    status: 'idle'
-  });
+
+  const savedDownloads = useLocalStore((s) =>
+    projectId ? (s.bibleDownloadTranslations[projectId] ?? []) : []
+  );
+  const addDownload = useLocalStore((s) => s.addBibleDownloadTranslation);
+  const removeDownload = useLocalStore((s) => s.removeBibleDownloadTranslation);
+
+  const isInDownloadList = savedDownloads.some((b) => b.bibleId === bible.id);
 
   const bookId = fiaBookId?.toUpperCase();
   const textCached =
@@ -446,17 +449,33 @@ function TranslationDownloadButton({
     bookId && verseRange && bible.audioFilesetId
       ? isBibleAudioCached(bible.audioFilesetId, bookId, verseRange)
       : false;
-
   const allCached =
     (textCached || !bible.hasText) && (audioCached || !bible.hasAudio);
 
-  const handleDownload = async () => {
-    if (!bookId || !verseRange || !supabaseUrl) return;
+  const [dlState, setDlState] = useState<DlBtnState>('idle');
+
+  const handleAdd = async () => {
+    if (!projectId || !bookId || !verseRange || !supabaseUrl) return;
+
+    addDownload(projectId, {
+      bibleId: bible.id,
+      name: bible.name,
+      vname: bible.vname,
+      textFilesetId: bible.textFilesetId,
+      audioFilesetId: bible.audioFilesetId,
+      hasText: bible.hasText,
+      hasAudio: bible.hasAudio
+    });
+
+    if (allCached) {
+      setDlState('done');
+      return;
+    }
+
     const parsed = parseFiaVerseRange(verseRange);
     if (!parsed) return;
 
-    setState({ status: 'downloading', label: 'Downloading text...' });
-
+    setDlState('downloading');
     try {
       if (!textCached && bible.textFilesetId) {
         const response = await fetch(
@@ -486,7 +505,6 @@ function TranslationDownloadButton({
             await cacheBibleText(bible.textFilesetId, bookId, verseRange, data);
           }
           if (bible.audioFilesetId && data.audio.length > 0 && !audioCached) {
-            setState({ status: 'downloading', label: 'Downloading audio...' });
             await downloadBibleAudio(
               bible.audioFilesetId,
               bookId,
@@ -496,7 +514,6 @@ function TranslationDownloadButton({
           }
         }
       } else if (!audioCached && bible.audioFilesetId && audioData?.length) {
-        setState({ status: 'downloading', label: 'Downloading audio...' });
         await downloadBibleAudio(
           bible.audioFilesetId,
           bookId,
@@ -504,47 +521,54 @@ function TranslationDownloadButton({
           audioData
         );
       }
-
-      setState({ status: 'done' });
-    } catch (e) {
-      setState({
-        status: 'error',
-        message: e instanceof Error ? e.message : 'Download failed'
-      });
+      setDlState('done');
+    } catch {
+      setDlState('error');
     }
   };
 
-  if (allCached || state.status === 'done') {
+  const handleRemove = () => {
+    if (!projectId) return;
+    removeDownload(projectId, bible.id);
+    setDlState('idle');
+  };
+
+  if (isInDownloadList && (allCached || dlState === 'done')) {
     return (
       <View className="flex-row items-center gap-2 rounded-lg bg-green-500/10 px-3 py-2">
         <View className="h-5 w-5 items-center justify-center rounded-full bg-green-500">
           <Icon as={CheckIcon} size={12} className="text-white" />
         </View>
-        <Text className="text-xs font-medium text-green-700 dark:text-green-400">
-          Available offline
+        <Text className="flex-1 text-xs font-medium text-green-700 dark:text-green-400">
+          Saved offline
         </Text>
+        <TouchableOpacity onPress={handleRemove} hitSlop={8}>
+          <Text className="text-xs text-muted-foreground underline">
+            Remove
+          </Text>
+        </TouchableOpacity>
       </View>
     );
   }
 
-  if (state.status === 'downloading') {
+  if (dlState === 'downloading') {
     return (
       <View className="bg-primary/8 flex-row items-center gap-2 rounded-lg px-3 py-2">
         <ActivityIndicator size="small" color={getThemeColor('primary')} />
-        <Text className="text-xs font-medium text-primary">{state.label}</Text>
+        <Text className="text-xs font-medium text-primary">Downloading...</Text>
       </View>
     );
   }
 
-  if (state.status === 'error') {
+  if (dlState === 'error') {
     return (
       <TouchableOpacity
-        onPress={handleDownload}
+        onPress={handleAdd}
         className="flex-row items-center gap-2 rounded-lg bg-destructive/10 px-3 py-2"
         activeOpacity={0.7}
       >
         <Text className="text-xs font-medium text-destructive">
-          Download failed — tap to retry
+          Failed — tap to retry
         </Text>
       </TouchableOpacity>
     );
@@ -554,13 +578,13 @@ function TranslationDownloadButton({
 
   return (
     <TouchableOpacity
-      onPress={handleDownload}
+      onPress={handleAdd}
       className="bg-primary/8 flex-row items-center gap-2 rounded-lg px-3 py-2"
       activeOpacity={0.7}
     >
       <Icon as={DownloadCloudIcon} size={16} className="text-primary" />
       <Text className="text-xs font-medium text-primary">
-        Download for offline
+        {isInDownloadList ? 'Re-download' : 'Add to offline'}
       </Text>
     </TouchableOpacity>
   );
@@ -825,9 +849,10 @@ export function BibleReaderContent({
       )}
 
       {selectedBible && (
-        <View className="flex-row items-center gap-2 px-1">
-          <TranslationDownloadButton
+        <View className="px-1">
+          <TranslationDownloadToggle
             bible={selectedBible}
+            projectId={projectId}
             fiaBookId={fiaBookId}
             verseRange={verseRange}
             audioData={content?.audio}

--- a/components/PericopeBibleDownloadDrawer.tsx
+++ b/components/PericopeBibleDownloadDrawer.tsx
@@ -14,6 +14,7 @@ import type { BibleBrainBible } from '@/hooks/useBibleBrainBibles';
 import { useBibleBrainBibles } from '@/hooks/useBibleBrainBibles';
 import type { BibleBrainContentResponse } from '@/hooks/useBibleBrainContent';
 import type { FiaPericope } from '@/hooks/useFiaBooks';
+import type { BibleDownloadTranslation } from '@/store/localStore';
 import { useLocalStore } from '@/store/localStore';
 import {
   cacheBibleText,
@@ -30,17 +31,14 @@ import {
   AlertCircleIcon,
   BookOpenIcon,
   CheckCircle2Icon,
+  CheckIcon,
+  DownloadCloudIcon,
   HeadphonesIcon,
   SkipForwardIcon,
   TypeIcon
 } from 'lucide-react-native';
 import React from 'react';
-import {
-  ActivityIndicator,
-  Switch,
-  TouchableOpacity,
-  View
-} from 'react-native';
+import { ActivityIndicator, Pressable, Switch, View } from 'react-native';
 
 type DownloadPhase = 'idle' | 'downloading' | 'done' | 'error';
 
@@ -55,16 +53,16 @@ function parseFiaVerseRange(verseRange: string) {
   };
 }
 
-function TranslationRow({
+function TranslationCheckboxRow({
   bible,
-  onSelect,
-  disabled,
+  checked,
+  onToggle,
   bookId,
   verseRange
 }: {
   bible: BibleBrainBible;
-  onSelect: (bible: BibleBrainBible) => void;
-  disabled: boolean;
+  checked: boolean;
+  onToggle: () => void;
   bookId: string;
   verseRange: string;
 }) {
@@ -77,15 +75,23 @@ function TranslationRow({
     : false;
 
   return (
-    <TouchableOpacity
-      onPress={() => onSelect(bible)}
-      disabled={disabled}
+    <Pressable
+      onPress={onToggle}
       className={cn(
-        'flex-row items-center gap-3 rounded-xl border border-border bg-card px-4 py-3 active:bg-accent',
-        disabled && 'opacity-50'
+        'flex-row items-center gap-3 rounded-xl border bg-card px-4 py-3 active:bg-accent',
+        checked ? 'border-primary' : 'border-border'
       )}
-      activeOpacity={0.7}
     >
+      <View
+        className={cn(
+          'h-6 w-6 items-center justify-center rounded-md border-2',
+          checked
+            ? 'border-primary bg-primary'
+            : 'border-muted-foreground bg-transparent'
+        )}
+      >
+        {checked && <Icon as={CheckIcon} size={14} className="text-white" />}
+      </View>
       <View className="h-10 w-10 items-center justify-center rounded-full bg-primary/10">
         <Icon as={BookOpenIcon} size={18} className="text-primary" />
       </View>
@@ -115,7 +121,7 @@ function TranslationRow({
           </View>
         )}
       </View>
-    </TouchableOpacity>
+    </Pressable>
   );
 }
 
@@ -142,12 +148,20 @@ export function PericopeBibleDownloadDrawer({
   const primaryColor = useThemeColor('primary');
   const supabaseUrl = process.env.EXPO_PUBLIC_SUPABASE_URL;
   const { bibles, isLoading: biblesLoading } = useBibleBrainBibles(projectId);
+
+  const savedDownloads = useLocalStore(
+    (s) => s.bibleDownloadTranslations[projectId] ?? []
+  );
+  const setBibleDownloadTranslations = useLocalStore(
+    (s) => s.setBibleDownloadTranslations
+  );
   const setBibleTranslation = useLocalStore((s) => s.setBibleTranslation);
 
   const [phase, setPhase] = React.useState<DownloadPhase>('idle');
   const [includeAudio, setIncludeAudio] = React.useState(true);
   const [errorMessage, setErrorMessage] = React.useState('');
   const [downloadLabel, setDownloadLabel] = React.useState('');
+  const [selectedIds, setSelectedIds] = React.useState<Set<string>>(new Set());
 
   const bookId = fiaBookId.toUpperCase();
   const parsed = pericope ? parseFiaVerseRange(pericope.verseRange) : null;
@@ -157,80 +171,98 @@ export function PericopeBibleDownloadDrawer({
       setPhase('idle');
       setErrorMessage('');
       setDownloadLabel('');
+      const initial = new Set(savedDownloads.map((b) => b.bibleId));
+      setSelectedIds(initial);
     }
-  }, [open]);
+  }, [open, savedDownloads]);
 
-  const handleSelect = async (bible: BibleBrainBible) => {
-    if (!parsed || !supabaseUrl || !pericope) return;
+  const toggleBible = (bibleId: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(bibleId)) {
+        next.delete(bibleId);
+      } else {
+        next.add(bibleId);
+      }
+      return next;
+    });
+  };
+
+  const downloadSingleBible = async (
+    bible: BibleBrainBible,
+    verseRange: string,
+    parsedRange: NonNullable<ReturnType<typeof parseFiaVerseRange>>
+  ) => {
+    const textCached = bible.textFilesetId
+      ? isBibleTextCached(bible.textFilesetId, bookId, verseRange)
+      : false;
+    const audioCached =
+      includeAudio && bible.audioFilesetId
+        ? isBibleAudioCached(bible.audioFilesetId, bookId, verseRange)
+        : false;
+
+    if (textCached && (!includeAudio || !bible.hasAudio || audioCached)) return;
+
+    const response = await fetch(
+      `${supabaseUrl}/functions/v1/bible-brain-content`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${session?.access_token ?? process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY}`
+        },
+        body: JSON.stringify({
+          action: 'get-content',
+          textFilesetId: bible.textFilesetId ?? null,
+          audioFilesetId:
+            includeAudio && bible.hasAudio
+              ? (bible.audioFilesetId ?? null)
+              : null,
+          bookId,
+          startChapter: parsedRange.startChapter,
+          startVerse: parsedRange.startVerse,
+          endChapter: parsedRange.endChapter,
+          endVerse: parsedRange.endVerse
+        })
+      }
+    );
+
+    if (!response.ok) return;
+    const data: BibleBrainContentResponse = await response.json();
+
+    if (bible.textFilesetId && data.verses.length > 0 && !textCached) {
+      await cacheBibleText(bible.textFilesetId, bookId, verseRange, data);
+    }
+
+    if (
+      includeAudio &&
+      bible.audioFilesetId &&
+      data.audio.length > 0 &&
+      !audioCached
+    ) {
+      await downloadBibleAudio(
+        bible.audioFilesetId,
+        bookId,
+        verseRange,
+        data.audio
+      );
+    }
+  };
+
+  const handleDownload = async () => {
+    if (!parsed || !supabaseUrl || !pericope || selectedIds.size === 0) return;
 
     setPhase('downloading');
-    setDownloadLabel('Downloading Bible content...');
+    const selectedBibles = bibles.filter((b) => selectedIds.has(b.id));
 
     try {
-      const textCached = bible.textFilesetId
-        ? isBibleTextCached(bible.textFilesetId, bookId, pericope.verseRange)
-        : false;
-      const audioCached =
-        includeAudio && bible.audioFilesetId
-          ? isBibleAudioCached(
-              bible.audioFilesetId,
-              bookId,
-              pericope.verseRange
-            )
-          : false;
-
-      if (!textCached || (includeAudio && bible.hasAudio && !audioCached)) {
-        const response = await fetch(
-          `${supabaseUrl}/functions/v1/bible-brain-content`,
-          {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-              Authorization: `Bearer ${session?.access_token ?? process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY}`
-            },
-            body: JSON.stringify({
-              action: 'get-content',
-              textFilesetId: bible.textFilesetId ?? null,
-              audioFilesetId:
-                includeAudio && bible.hasAudio
-                  ? (bible.audioFilesetId ?? null)
-                  : null,
-              bookId,
-              startChapter: parsed.startChapter,
-              startVerse: parsed.startVerse,
-              endChapter: parsed.endChapter,
-              endVerse: parsed.endVerse
-            })
-          }
+      for (let i = 0; i < selectedBibles.length; i++) {
+        const bible = selectedBibles[i]!;
+        const label = bible.vname || bible.name;
+        setDownloadLabel(
+          `Downloading ${label} (${i + 1}/${selectedBibles.length})...`
         );
-
-        if (response.ok) {
-          const data: BibleBrainContentResponse = await response.json();
-
-          if (bible.textFilesetId && data.verses.length > 0 && !textCached) {
-            await cacheBibleText(
-              bible.textFilesetId,
-              bookId,
-              pericope.verseRange,
-              data
-            );
-          }
-
-          if (
-            includeAudio &&
-            bible.audioFilesetId &&
-            data.audio.length > 0 &&
-            !audioCached
-          ) {
-            setDownloadLabel('Downloading audio...');
-            await downloadBibleAudio(
-              bible.audioFilesetId,
-              bookId,
-              pericope.verseRange,
-              data.audio
-            );
-          }
-        }
+        await downloadSingleBible(bible, pericope.verseRange, parsed);
       }
 
       setDownloadLabel('Downloading guide content...');
@@ -242,15 +274,31 @@ export function PericopeBibleDownloadDrawer({
         );
       }
 
-      setBibleTranslation(projectId, {
-        bibleId: bible.id,
-        name: bible.name,
-        vname: bible.vname,
-        textFilesetId: bible.textFilesetId,
-        audioFilesetId: bible.audioFilesetId,
-        hasText: bible.hasText,
-        hasAudio: bible.hasAudio
-      });
+      const translationsToSave: BibleDownloadTranslation[] = selectedBibles.map(
+        (b) => ({
+          bibleId: b.id,
+          name: b.name,
+          vname: b.vname,
+          textFilesetId: b.textFilesetId,
+          audioFilesetId: b.audioFilesetId,
+          hasText: b.hasText,
+          hasAudio: b.hasAudio
+        })
+      );
+      setBibleDownloadTranslations(projectId, translationsToSave);
+
+      if (selectedBibles.length > 0) {
+        const first = selectedBibles[0]!;
+        setBibleTranslation(projectId, {
+          bibleId: first.id,
+          name: first.name,
+          vname: first.vname,
+          textFilesetId: first.textFilesetId,
+          audioFilesetId: first.audioFilesetId,
+          hasText: first.hasText,
+          hasAudio: first.hasAudio
+        });
+      }
 
       setPhase('done');
 
@@ -278,22 +326,24 @@ export function PericopeBibleDownloadDrawer({
     onSkip();
   };
 
+  const selectedCount = selectedIds.size;
+
   return (
-    <Drawer open={open} onOpenChange={handleClose}>
+    <Drawer open={open} onOpenChange={handleClose} snapPoints={['80%']}>
       <DrawerContent>
         <DrawerHeader>
           <DrawerTitle>
             Download {pericope?.verseRange ?? 'Pericope'}
           </DrawerTitle>
           <DrawerDescription>
-            Choose a Bible translation to download for this pericope
+            Select Bible translations to download for offline use
           </DrawerDescription>
         </DrawerHeader>
 
         {phase === 'downloading' ? (
           <View className="items-center gap-3 px-4 py-8">
             <ActivityIndicator size="large" color={primaryColor} />
-            <Text className="text-sm text-muted-foreground">
+            <Text className="text-center text-sm text-muted-foreground">
               {downloadLabel}
             </Text>
           </View>
@@ -369,16 +419,16 @@ export function PericopeBibleDownloadDrawer({
               />
             </View>
 
-            <DrawerScrollView style={{ maxHeight: 360 }}>
+            <DrawerScrollView style={{ flex: 1 }}>
               <View className="gap-2 px-4 pb-4">
                 {bibles
                   .filter((b) => b.hasText || b.hasAudio)
                   .map((bible) => (
-                    <TranslationRow
+                    <TranslationCheckboxRow
                       key={bible.id}
                       bible={bible}
-                      onSelect={handleSelect}
-                      disabled={false}
+                      checked={selectedIds.has(bible.id)}
+                      onToggle={() => toggleBible(bible.id)}
                       bookId={bookId}
                       verseRange={pericope?.verseRange ?? ''}
                     />
@@ -386,7 +436,22 @@ export function PericopeBibleDownloadDrawer({
               </View>
             </DrawerScrollView>
 
-            <View className="items-center px-4 pb-4">
+            <View className="gap-2 border-t border-border px-4 pb-4 pt-3">
+              <Button
+                onPress={handleDownload}
+                disabled={selectedCount === 0}
+                className="flex-row items-center gap-2"
+              >
+                <Icon
+                  as={DownloadCloudIcon}
+                  size={18}
+                  className="text-primary-foreground"
+                />
+                <Text className="font-semibold text-primary-foreground">
+                  Download {selectedCount}{' '}
+                  {selectedCount === 1 ? 'translation' : 'translations'}
+                </Text>
+              </Button>
               <Button variant="ghost" size="sm" onPress={handleSkip}>
                 <Icon
                   as={SkipForwardIcon}

--- a/db/powersync/FiaAttachmentQueue.ts
+++ b/db/powersync/FiaAttachmentQueue.ts
@@ -97,17 +97,18 @@ export class FiaAttachmentQueue extends AbstractAttachmentQueue {
   }
 
   /**
-   * Syncs bible content for the user's saved translation alongside FIA guide content.
-   * Reads the saved translation from localStore and queries quest metadata for verse range.
+   * Syncs bible content for all of the user's saved download translations
+   * alongside FIA guide content. Reads the saved list from localStore
+   * and queries quest metadata for verse range.
    */
   private async syncBibleContent(
     projectId: string,
     pericopeId: string,
     token: string | undefined
   ): Promise<void> {
-    const savedBible =
-      useLocalStore.getState().bibleTranslationByProject[projectId];
-    if (!savedBible?.textFilesetId) return;
+    const savedBibles =
+      useLocalStore.getState().bibleDownloadTranslations[projectId];
+    if (!savedBibles?.length) return;
 
     const questMeta = await this.powersync.getAll<{
       verseRange: string;
@@ -132,10 +133,6 @@ export class FiaAttachmentQueue extends AbstractAttachmentQueue {
     const bookId = meta.bookId.toUpperCase();
     const verseRange = meta.verseRange;
 
-    if (isBibleTextCached(savedBible.textFilesetId, bookId, verseRange)) {
-      return;
-    }
-
     const match = verseRange.match(
       /^(\d+):(\d+)[a-z]?-(?:(\d+):)?(\d+)[a-z]?$/
     );
@@ -150,53 +147,64 @@ export class FiaAttachmentQueue extends AbstractAttachmentQueue {
 
     const supabaseUrl = process.env.EXPO_PUBLIC_SUPABASE_URL;
     if (!supabaseUrl) return;
-
     const anonKey = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY;
-    const response = await fetch(
-      `${supabaseUrl}/functions/v1/bible-brain-content`,
-      {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${token ?? anonKey}`
-        },
-        body: JSON.stringify({
-          action: 'get-content',
-          textFilesetId: savedBible.textFilesetId,
-          audioFilesetId: savedBible.audioFilesetId,
-          bookId,
-          startChapter: parsed.startChapter,
-          startVerse: parsed.startVerse,
-          endChapter: parsed.endChapter,
-          endVerse: parsed.endVerse
-        })
+
+    for (const bible of savedBibles) {
+      if (!bible.textFilesetId) continue;
+      if (isBibleTextCached(bible.textFilesetId, bookId, verseRange)) continue;
+
+      try {
+        const response = await fetch(
+          `${supabaseUrl}/functions/v1/bible-brain-content`,
+          {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              Authorization: `Bearer ${token ?? anonKey}`
+            },
+            body: JSON.stringify({
+              action: 'get-content',
+              textFilesetId: bible.textFilesetId,
+              audioFilesetId: bible.audioFilesetId,
+              bookId,
+              startChapter: parsed.startChapter,
+              startVerse: parsed.startVerse,
+              endChapter: parsed.endChapter,
+              endVerse: parsed.endVerse
+            })
+          }
+        );
+
+        if (!response.ok) continue;
+        const data = await response.json();
+
+        if (bible.textFilesetId && data.verses?.length > 0) {
+          await cacheBibleText(bible.textFilesetId, bookId, verseRange, data);
+        }
+
+        if (
+          bible.audioFilesetId &&
+          data.audio?.length > 0 &&
+          !isBibleAudioCached(bible.audioFilesetId, bookId, verseRange)
+        ) {
+          await downloadBibleAudio(
+            bible.audioFilesetId,
+            bookId,
+            verseRange,
+            data.audio
+          );
+        }
+
+        console.log(
+          `[FIA Queue] Bible synced for ${pericopeId} (${bible.bibleId})`
+        );
+      } catch (e) {
+        console.warn(
+          `[FIA Queue] Bible sync failed for ${pericopeId}/${bible.bibleId}:`,
+          e
+        );
       }
-    );
-
-    if (!response.ok) return;
-
-    const data = await response.json();
-
-    if (savedBible.textFilesetId && data.verses?.length > 0) {
-      await cacheBibleText(savedBible.textFilesetId, bookId, verseRange, data);
     }
-
-    if (
-      savedBible.audioFilesetId &&
-      data.audio?.length > 0 &&
-      !isBibleAudioCached(savedBible.audioFilesetId, bookId, verseRange)
-    ) {
-      await downloadBibleAudio(
-        savedBible.audioFilesetId,
-        bookId,
-        verseRange,
-        data.audio
-      );
-    }
-
-    console.log(
-      `[FIA Queue] Bible content synced for ${pericopeId} (${savedBible.textFilesetId})`
-    );
   }
 
   async downloadRecord(record: AttachmentRecord): Promise<boolean> {

--- a/store/localStore.ts
+++ b/store/localStore.ts
@@ -108,6 +108,16 @@ export interface RecentAsset {
   visitedAt: Date;
 }
 
+export interface BibleDownloadTranslation {
+  bibleId: string;
+  name: string;
+  vname: string | null;
+  textFilesetId: string | null;
+  audioFilesetId: string | null;
+  hasText: boolean;
+  hasAudio: boolean;
+}
+
 export interface LocalState {
   systemReady: boolean;
   setSystemReady: (ready: boolean) => void;
@@ -306,6 +316,18 @@ export interface LocalState {
   bibleRecentTranslations: Record<string, string[]>;
   bibleAudioPositions: Record<string, number>;
   setBibleAudioPosition: (key: string, positionMs: number) => void;
+
+  // Saved Bible download translations (multi-select per project)
+  bibleDownloadTranslations: Record<string, BibleDownloadTranslation[]>;
+  setBibleDownloadTranslations: (
+    projectId: string,
+    bibles: BibleDownloadTranslation[]
+  ) => void;
+  addBibleDownloadTranslation: (
+    projectId: string,
+    bible: BibleDownloadTranslation
+  ) => void;
+  removeBibleDownloadTranslation: (projectId: string, bibleId: string) => void;
 }
 
 export const useLocalStore = create<LocalState>()(
@@ -647,7 +669,38 @@ export const useLocalStore = create<LocalState>()(
             ...state.bibleAudioPositions,
             [key]: positionMs
           }
-        }))
+        })),
+
+      // Saved Bible download translations (multi-select per project)
+      bibleDownloadTranslations: {},
+      setBibleDownloadTranslations: (projectId, bibles) =>
+        set((state) => ({
+          bibleDownloadTranslations: {
+            ...state.bibleDownloadTranslations,
+            [projectId]: bibles
+          }
+        })),
+      addBibleDownloadTranslation: (projectId, bible) =>
+        set((state) => {
+          const existing = state.bibleDownloadTranslations[projectId] ?? [];
+          if (existing.some((b) => b.bibleId === bible.bibleId)) return state;
+          return {
+            bibleDownloadTranslations: {
+              ...state.bibleDownloadTranslations,
+              [projectId]: [...existing, bible]
+            }
+          };
+        }),
+      removeBibleDownloadTranslation: (projectId, bibleId) =>
+        set((state) => {
+          const existing = state.bibleDownloadTranslations[projectId] ?? [];
+          return {
+            bibleDownloadTranslations: {
+              ...state.bibleDownloadTranslations,
+              [projectId]: existing.filter((b) => b.bibleId !== bibleId)
+            }
+          };
+        })
     }),
     {
       name: 'local-store',

--- a/views/new/FiaPericopeList.tsx
+++ b/views/new/FiaPericopeList.tsx
@@ -337,8 +337,8 @@ export function FiaPericopeList({
     questData?: Record<string, unknown>;
     pericope: FiaPericope;
   } | null>(null);
-  const savedBible = useLocalStore(
-    (s) => s.bibleTranslationByProject[projectId]
+  const savedDownloads = useLocalStore(
+    (s) => s.bibleDownloadTranslations[projectId] ?? []
   );
 
   // Version picker state
@@ -517,12 +517,19 @@ export function FiaPericopeList({
     questData: Record<string, unknown> | undefined,
     pericope: FiaPericope
   ) => {
-    const bookId = book.id.toUpperCase();
-    const hasCached = savedBible?.textFilesetId
-      ? isBibleTextCached(savedBible.textFilesetId, bookId, pericope.verseRange)
-      : false;
+    if (savedDownloads.length === 0) {
+      setPendingNav({ questId, questName, questData, pericope });
+      return;
+    }
 
-    if (hasCached) {
+    const bookId = book.id.toUpperCase();
+    const allCached = savedDownloads.every((b) =>
+      b.textFilesetId
+        ? isBibleTextCached(b.textFilesetId, bookId, pericope.verseRange)
+        : true
+    );
+
+    if (allCached) {
       goToQuest({
         id: questId,
         project_id: projectId,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Enables pre-pericope Bible content download and syncing with pericope media to enhance the offline reading experience.

This PR introduces a new download drawer that appears before opening a pericope if the selected Bible translation isn't cached, allowing users to download text and audio. It also adds a button to the FIA drawer for downloading additional translations and modifies the attachment queue to automatically sync the user's saved Bible content when pericope media is downloaded.

<div><a href="https://cursor.com/agents/bc-cc342df5-7a79-4823-9fd6-40d29bccbf13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cc342df5-7a79-4823-9fd6-40d29bccbf13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->