### PR TITLE
feat(db): add uploaded_at column for server-confirmed upload time

### DIFF
--- a/supabase/migrations/20260505180000_add_uploaded_at_to_translator_content.sql
+++ b/supabase/migrations/20260505180000_add_uploaded_at_to_translator_content.sql
@@ -1,0 +1,36 @@
+-- Migration: Add uploaded_at column to translator-content tables
+-- Version: 2.3 → 2.4 (minor bump - additive change)
+-- Purpose: Track server-confirmed upload time for translator-payment reporting
+--
+-- Tables affected:
+--   - asset_content_link (translation/transcription content)
+--   - vote (peer review activity)
+--   - asset (field-created assets)
+--
+-- Design decisions:
+--   - Column is nullable: no backfill for existing rows (as per contract)
+--   - Default is now() at column level: no trigger, no app-level write
+--   - Populated by Postgres on INSERT: clients MUST NOT include in mutation payloads
+--   - Independent of created_at/last_updated: reflects server clock only
+--   - Immutable after INSERT: no UPDATE code path modifies this column
+
+-- Add uploaded_at to asset_content_link table
+alter table asset_content_link
+  add column if not exists uploaded_at timestamptz null default now();
+
+comment on column asset_content_link.uploaded_at is
+  'Server-confirmed upload time for payment reporting. Set by DEFAULT now() on INSERT. Clients must not write this column.';
+
+-- Add uploaded_at to vote table
+alter table vote
+  add column if not exists uploaded_at timestamptz null default now();
+
+comment on column vote.uploaded_at is
+  'Server-confirmed upload time for payment reporting. Set by DEFAULT now() on INSERT. Clients must not write this column.';
+
+-- Add uploaded_at to asset table
+alter table asset
+  add column if not exists uploaded_at timestamptz null default now();
+
+comment on column asset.uploaded_at is
+  'Server-confirmed upload time for payment reporting. Set by DEFAULT now() on INSERT. Clients must not write this column.';


### PR DESCRIPTION
## Summary

Track server-confirmed upload time on translator-content tables, distinct from client-side `created_at`.

## Scope

Add `uploaded_at timestamptz NULL DEFAULT now()` to synced content tables:

- `asset_content_link` — translation/transcription content
- `vote` — peer review activity
- `asset` — field-created assets

## Behavior

### Inputs
- None from the client. Column is populated by Postgres `DEFAULT now()` on `INSERT`.
- Mutations continue to flow through the existing `apply_table_mutation_transaction` RPC unchanged.

### Outputs
- New rows: `uploaded_at` = server clock at the moment of INSERT.
- Pre-existing rows: `uploaded_at` = `NULL` (no backfill).
- Column syncs down to clients via PowerSync and is available to reporting queries.

### Invariants
- Immutable after INSERT (no code path UPDATEs it).
- Reflects server clock only; never client clock.
- Independent of `created_at` and `last_updated`.
- Always `timestamptz`, matching `created_at`.

### Validation Rules
- Column is nullable; no `NOT NULL` constraint.
- Default is `now()` at the column level — no trigger, no app-level write.
- Clients MUST NOT include `uploaded_at` in mutation payloads. The client schema does not expose it for write, so this is enforced by omission. If a payload ever contains it, the value MUST be ignored so the server clock remains authoritative.

## Implementation Notes

- One Supabase migration adding the column to each scoped table.
- No `APP_SCHEMA_VERSION` / `get_schema_info()` bump — server-only column, no client-side migration.
- `drizzleSchemaColumns.ts` update only needed if a client surface (UI, query) ever has to read `uploaded_at`. Until then, left out of the client schema.

## Error Conditions Handled

- Migration re-run on a table that already has the column → idempotent via `ADD COLUMN IF NOT EXISTS`.
- Reporting code reading `uploaded_at` for old rows → must handle `NULL` gracefully.

## Non-Goals

- Do **not** backfill existing rows.
- Do **not** add a trigger; rely on `DEFAULT now()`.
- Do **not** modify `apply_table_mutation_transaction` logic.
- Do **not** replace or alter `created_at` / `last_updated`.
- Do **not** add the column to `*_local` SQLite tables for client write.
- Do **not** create a separate upload-tracking table, audit log, or new RPC.

## Test Plan

- [ ] Verify migration applies cleanly to existing database
- [ ] Confirm column populates automatically on new INSERTs
- [ ] Verify existing rows remain NULL (no backfill)
- [ ] Test idempotency: migration can be re-run without error

Made with [Cursor](https://cursor.com)