### PR TITLE
fix(fia): key pericope cache and download queue by language code

### DIFF
--- a/components/FiaStepDrawer.tsx
+++ b/components/FiaStepDrawer.tsx
@@ -29,6 +29,7 @@ import type {
   FiaTerm
 } from '@/hooks/useFiaPericopeSteps';
 import { useFiaPericopeSteps } from '@/hooks/useFiaPericopeSteps';
+import { useProjectFiaLanguageCode } from '@/hooks/useProjectFiaLanguageCode';
 import {
   enqueue as enqueueFiaAttachment,
   isFiaPericopeCached,
@@ -886,21 +887,31 @@ export function FiaStepDrawer({
   );
   const scrollRef = React.useRef<any>(null);
   const dataLoadedRef = React.useRef(false);
+  const { fiaLanguageCode } = useProjectFiaLanguageCode(
+    pericopeId ? projectId : undefined
+  );
+
   const { data, isLoading, error } = useFiaPericopeSteps(
     pericopeId ? projectId : undefined,
     pericopeId ?? undefined
   );
 
-  const attachmentStatus = useFiaAttachmentStatus(pericopeId);
+  const attachmentStatus = useFiaAttachmentStatus(pericopeId, fiaLanguageCode);
   const isAudioDownloading =
     attachmentStatus?.status === 'pending' ||
     attachmentStatus?.status === 'downloading';
 
   React.useEffect(() => {
-    if (open && pericopeId && projectId && !isFiaPericopeCached(pericopeId)) {
+    if (
+      open &&
+      pericopeId &&
+      projectId &&
+      fiaLanguageCode &&
+      !isFiaPericopeCached(fiaLanguageCode, pericopeId)
+    ) {
       enqueueFiaAttachment(pericopeId, projectId);
     }
-  }, [open, pericopeId, projectId]);
+  }, [open, pericopeId, projectId, fiaLanguageCode]);
 
   const currentStep = data?.steps.find((s) => s.stepId === activeStep);
   const audioUrl = currentStep?.audioUrl ?? null;

--- a/hooks/useFiaPericopeSteps.ts
+++ b/hooks/useFiaPericopeSteps.ts
@@ -2,6 +2,7 @@ import {
   getCachedFiaPericope,
   useFiaAttachmentStatus
 } from '@/services/FiaAttachmentQueue';
+import { useProjectFiaLanguageCode } from '@/hooks/useProjectFiaLanguageCode';
 import { useQuery } from '@tanstack/react-query';
 
 // --- Types matching the edge function response ---
@@ -62,19 +63,29 @@ export function useFiaPericopeSteps(
   projectId: string | undefined,
   pericopeId: string | undefined
 ) {
-  const attachmentStatus = useFiaAttachmentStatus(pericopeId);
+  const { fiaLanguageCode } = useProjectFiaLanguageCode(projectId);
+
+  const attachmentStatus = useFiaAttachmentStatus(
+    pericopeId,
+    fiaLanguageCode
+  );
 
   // completedAt changes when the queue finishes, causing the query to re-run
   // and pick up the freshly-cached file
   const cacheVersion = attachmentStatus?.completedAt ?? 0;
 
   const { data, isLoading, error } = useQuery({
-    queryKey: ['fia-pericope-steps', projectId, pericopeId, cacheVersion],
+    queryKey: [
+      'fia-pericope-steps',
+      fiaLanguageCode,
+      pericopeId,
+      cacheVersion
+    ],
     queryFn: (): FiaPericopeStepsResponse | null => {
-      if (!pericopeId) return null;
-      return getCachedFiaPericope(pericopeId);
+      if (!pericopeId || !fiaLanguageCode) return null;
+      return getCachedFiaPericope(fiaLanguageCode, pericopeId);
     },
-    enabled: !!projectId && !!pericopeId,
+    enabled: !!fiaLanguageCode && !!pericopeId,
     staleTime: Infinity,
     gcTime: 1000 * 60 * 60,
     refetchInterval: false,

--- a/hooks/useFiaPericopeSteps.ts
+++ b/hooks/useFiaPericopeSteps.ts
@@ -65,22 +65,14 @@ export function useFiaPericopeSteps(
 ) {
   const { fiaLanguageCode } = useProjectFiaLanguageCode(projectId);
 
-  const attachmentStatus = useFiaAttachmentStatus(
-    pericopeId,
-    fiaLanguageCode
-  );
+  const attachmentStatus = useFiaAttachmentStatus(pericopeId, fiaLanguageCode);
 
   // completedAt changes when the queue finishes, causing the query to re-run
   // and pick up the freshly-cached file
   const cacheVersion = attachmentStatus?.completedAt ?? 0;
 
   const { data, isLoading, error } = useQuery({
-    queryKey: [
-      'fia-pericope-steps',
-      fiaLanguageCode,
-      pericopeId,
-      cacheVersion
-    ],
+    queryKey: ['fia-pericope-steps', fiaLanguageCode, pericopeId, cacheVersion],
     queryFn: (): FiaPericopeStepsResponse | null => {
       if (!pericopeId || !fiaLanguageCode) return null;
       return getCachedFiaPericope(fiaLanguageCode, pericopeId);

--- a/hooks/useProjectFiaLanguageCode.ts
+++ b/hooks/useProjectFiaLanguageCode.ts
@@ -1,0 +1,24 @@
+/**
+ * Resolves the FIA API language code (e.g. "eng", "fra") for a project's source languoid.
+ */
+
+import { useProjectSourceLanguoid } from '@/hooks/useProjectSourceLanguoid';
+import { lookupFiaLanguageCode } from '@/utils/languoidLookups';
+import { useQuery } from '@tanstack/react-query';
+
+export function useProjectFiaLanguageCode(projectId: string | undefined) {
+  const { sourceLanguoidId, isLoading: sourceLoading } =
+    useProjectSourceLanguoid(projectId ?? '');
+
+  const { data: fiaLanguageCode, isLoading: codeLoading } = useQuery({
+    queryKey: ['fia-language-code', sourceLanguoidId],
+    queryFn: () => lookupFiaLanguageCode(sourceLanguoidId!),
+    enabled: !!sourceLanguoidId,
+    staleTime: Infinity
+  });
+
+  return {
+    fiaLanguageCode: fiaLanguageCode ?? null,
+    isLoading: sourceLoading || codeLoading
+  };
+}

--- a/services/FiaAttachmentQueue.ts
+++ b/services/FiaAttachmentQueue.ts
@@ -9,9 +9,11 @@
 
 import { system } from '@/db/powersync/system';
 import type { FiaPericopeStepsResponse } from '@/hooks/useFiaPericopeSteps';
-import type { FiaAttachmentQueueItem } from '@/store/localStore';
+import type {
+  FiaAttachmentQueueItem,
+  FiaPericopeCacheKey
+} from '@/store/localStore';
 import { useLocalStore } from '@/store/localStore';
-import { useShallow } from 'zustand/react/shallow';
 import { getCachedAudioUri } from '@/utils/audioCache';
 import {
   downloadFile,
@@ -21,16 +23,17 @@ import {
   readFileText,
   writeFile
 } from '@/utils/fileUtils';
-import {
-  lookupFiaLanguageCode,
-  lookupSourceLanguoidId
-} from '@/utils/languoidLookups';
+import { lookupFiaLanguageCodeForProject } from '@/utils/languoidLookups';
+import { useShallow } from 'zustand/react/shallow';
 
 const FIA_DIR = 'fia_attachments';
 const IMAGES_DIR = `${FIA_DIR}/images`;
 
-function pericopeDataPath(pericopeId: string): string {
-  return `${getDocumentDirectory()}/${FIA_DIR}/${pericopeId}/response.json`;
+function pericopeDataPath(
+  fiaLanguageCode: string,
+  pericopeId: string
+): string {
+  return `${getDocumentDirectory()}/${FIA_DIR}/${fiaLanguageCode}/${pericopeId}/response.json`;
 }
 
 function imageCachePath(url: string): string {
@@ -79,18 +82,29 @@ function extractAudioUrls(data: FiaPericopeStepsResponse): string[] {
   return urls;
 }
 
+function queueKey(item: FiaPericopeCacheKey): FiaPericopeCacheKey {
+  return {
+    fiaLanguageCode: item.fiaLanguageCode,
+    pericopeId: item.pericopeId
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Public cache access (used by hooks and components)
 // ---------------------------------------------------------------------------
 
-export function isFiaPericopeCached(pericopeId: string): boolean {
-  return fileExists(pericopeDataPath(pericopeId));
+export function isFiaPericopeCached(
+  fiaLanguageCode: string,
+  pericopeId: string
+): boolean {
+  return fileExists(pericopeDataPath(fiaLanguageCode, pericopeId));
 }
 
 export function getCachedFiaPericope(
+  fiaLanguageCode: string,
   pericopeId: string
 ): FiaPericopeStepsResponse | null {
-  const path = pericopeDataPath(pericopeId);
+  const path = pericopeDataPath(fiaLanguageCode, pericopeId);
   if (!fileExists(path)) return null;
   try {
     return JSON.parse(readFileText(path)) as FiaPericopeStepsResponse;
@@ -134,7 +148,23 @@ function pendingItems(): FiaAttachmentQueueItem[] {
 }
 
 export function enqueue(pericopeId: string, projectId: string) {
-  getStore().enqueueFiaAttachment({ pericopeId, projectId });
+  void enqueueInternal(pericopeId, projectId);
+}
+
+async function enqueueInternal(pericopeId: string, projectId: string) {
+  const fiaLanguageCode = await lookupFiaLanguageCodeForProject(projectId);
+  if (!fiaLanguageCode) {
+    console.error(
+      `[FiaAttachmentQueue] Cannot enqueue ${pericopeId}: no FIA language code for project ${projectId}`
+    );
+    return;
+  }
+
+  getStore().enqueueFiaAttachment({
+    pericopeId,
+    projectId,
+    fiaLanguageCode
+  });
   void processQueue();
 }
 
@@ -144,7 +174,7 @@ export function initializeFiaQueue() {
     (i) => i.status === 'downloading'
   );
   for (const item of stuck) {
-    store.updateFiaAttachment(item.pericopeId, { status: 'pending' });
+    store.updateFiaAttachment(queueKey(item), { status: 'pending' });
   }
   if (pendingItems().length > 0) {
     console.log(
@@ -171,52 +201,61 @@ async function processQueue() {
 }
 
 async function processItem(item: FiaAttachmentQueueItem) {
-  const { pericopeId, projectId } = item;
+  const { pericopeId, fiaLanguageCode } = item;
+  const key = queueKey(item);
   const store = getStore();
 
-  if (isFiaPericopeCached(pericopeId)) {
-    store.updateFiaAttachment(pericopeId, {
+  if (isFiaPericopeCached(fiaLanguageCode, pericopeId)) {
+    store.updateFiaAttachment(key, {
       status: 'completed',
       completedAt: Date.now()
     });
     return;
   }
 
-  store.updateFiaAttachment(pericopeId, { status: 'downloading' });
-  console.log(`[FiaAttachmentQueue] Processing ${pericopeId}...`);
+  store.updateFiaAttachment(key, { status: 'downloading' });
+  console.log(
+    `[FiaAttachmentQueue] Processing ${fiaLanguageCode}/${pericopeId}...`
+  );
 
   try {
     ensureDir(`${getDocumentDirectory()}/${FIA_DIR}`);
+    ensureDir(`${getDocumentDirectory()}/${FIA_DIR}/${fiaLanguageCode}`);
 
-    const data = await fetchPericopeSteps(projectId, pericopeId);
+    const data = await fetchPericopeSteps(fiaLanguageCode, pericopeId);
     if (!data) throw new Error('Empty response from edge function');
 
     const imageUrls = extractImageUrls(data);
     console.log(
-      `[FiaAttachmentQueue] Downloading ${imageUrls.length} images for ${pericopeId}...`
+      `[FiaAttachmentQueue] Downloading ${imageUrls.length} images for ${fiaLanguageCode}/${pericopeId}...`
     );
     await downloadImages(imageUrls);
 
     const audioUrls = extractAudioUrls(data);
     console.log(
-      `[FiaAttachmentQueue] Downloading ${audioUrls.length} step audio files for ${pericopeId}...`
+      `[FiaAttachmentQueue] Downloading ${audioUrls.length} step audio files for ${fiaLanguageCode}/${pericopeId}...`
     );
     await downloadAudioFiles(audioUrls);
 
-    writeFile(pericopeDataPath(pericopeId), JSON.stringify(data));
+    writeFile(
+      pericopeDataPath(fiaLanguageCode, pericopeId),
+      JSON.stringify(data)
+    );
 
-    getStore().updateFiaAttachment(pericopeId, {
+    getStore().updateFiaAttachment(key, {
       status: 'completed',
       completedAt: Date.now()
     });
 
     console.log(
-      `[FiaAttachmentQueue] ✓ ${pericopeId} (${imageUrls.length} images, ${audioUrls.length} audio)`
+      `[FiaAttachmentQueue] ✓ ${fiaLanguageCode}/${pericopeId} (${imageUrls.length} images, ${audioUrls.length} audio)`
     );
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
-    console.error(`[FiaAttachmentQueue] ✗ ${pericopeId}: ${msg}`);
-    getStore().updateFiaAttachment(pericopeId, {
+    console.error(
+      `[FiaAttachmentQueue] ✗ ${fiaLanguageCode}/${pericopeId}: ${msg}`
+    );
+    getStore().updateFiaAttachment(key, {
       status: 'failed',
       error: msg
     });
@@ -237,23 +276,9 @@ function fetchWithTimeout(
 }
 
 async function fetchPericopeSteps(
-  projectId: string,
+  fiaLanguageCode: string,
   pericopeId: string
 ): Promise<FiaPericopeStepsResponse> {
-  console.log(
-    `[FiaAttachmentQueue] Looking up languoid for project ${projectId}...`
-  );
-  const sourceLanguoidId = await lookupSourceLanguoidId(projectId);
-  if (!sourceLanguoidId)
-    throw new Error('Could not find source languoid for project');
-
-  console.log(
-    `[FiaAttachmentQueue] Looking up FIA code for languoid ${sourceLanguoidId}...`
-  );
-  const fiaCode = await lookupFiaLanguageCode(sourceLanguoidId);
-  if (!fiaCode)
-    throw new Error(`No FIA language code for languoid ${sourceLanguoidId}`);
-
   const supabaseUrl = process.env.EXPO_PUBLIC_SUPABASE_URL;
   if (!supabaseUrl)
     throw new Error('EXPO_PUBLIC_SUPABASE_URL is not configured');
@@ -268,7 +293,7 @@ async function fetchPericopeSteps(
 
   const url = `${supabaseUrl}/functions/v1/fia-pericope-steps`;
   console.log(
-    `[FiaAttachmentQueue] Fetching edge function: ${url} (fiaCode=${fiaCode}, pericopeId=${pericopeId})`
+    `[FiaAttachmentQueue] Fetching edge function: ${url} (fiaCode=${fiaLanguageCode}, pericopeId=${pericopeId})`
   );
 
   const res = await fetchWithTimeout(
@@ -279,7 +304,7 @@ async function fetchPericopeSteps(
         'Content-Type': 'application/json',
         Authorization: `Bearer ${token}`
       },
-      body: JSON.stringify({ pericopeId, fiaLanguageCode: fiaCode })
+      body: JSON.stringify({ pericopeId, fiaLanguageCode })
     },
     FETCH_TIMEOUT_MS
   );
@@ -290,7 +315,7 @@ async function fetchPericopeSteps(
   }
 
   console.log(
-    `[FiaAttachmentQueue] Edge function responded OK for ${pericopeId}`
+    `[FiaAttachmentQueue] Edge function responded OK for ${fiaLanguageCode}/${pericopeId}`
   );
   return res.json();
 }
@@ -355,12 +380,17 @@ function scheduleRetry() {
 // Hook for components to observe a single pericope's status
 // ---------------------------------------------------------------------------
 
-export function useFiaAttachmentStatus(pericopeId: string | undefined) {
+export function useFiaAttachmentStatus(
+  pericopeId: string | undefined,
+  fiaLanguageCode: string | null | undefined
+) {
   const status = useLocalStore(
     useShallow((state) => {
-      if (!pericopeId) return undefined;
+      if (!pericopeId || !fiaLanguageCode) return undefined;
       const item = state.fiaAttachmentQueue.find(
-        (i) => i.pericopeId === pericopeId
+        (i) =>
+          i.pericopeId === pericopeId &&
+          i.fiaLanguageCode === fiaLanguageCode
       );
       if (!item) return undefined;
       return {

--- a/services/FiaAttachmentQueue.ts
+++ b/services/FiaAttachmentQueue.ts
@@ -29,10 +29,7 @@ import { useShallow } from 'zustand/react/shallow';
 const FIA_DIR = 'fia_attachments';
 const IMAGES_DIR = `${FIA_DIR}/images`;
 
-function pericopeDataPath(
-  fiaLanguageCode: string,
-  pericopeId: string
-): string {
+function pericopeDataPath(fiaLanguageCode: string, pericopeId: string): string {
   return `${getDocumentDirectory()}/${FIA_DIR}/${fiaLanguageCode}/${pericopeId}/response.json`;
 }
 
@@ -389,8 +386,7 @@ export function useFiaAttachmentStatus(
       if (!pericopeId || !fiaLanguageCode) return undefined;
       const item = state.fiaAttachmentQueue.find(
         (i) =>
-          i.pericopeId === pericopeId &&
-          i.fiaLanguageCode === fiaLanguageCode
+          i.pericopeId === pericopeId && i.fiaLanguageCode === fiaLanguageCode
       );
       if (!item) return undefined;
       return {

--- a/store/localStore.ts
+++ b/store/localStore.ts
@@ -43,13 +43,30 @@ export type FiaAttachmentStatus =
   | 'completed'
   | 'failed';
 
-export interface FiaAttachmentQueueItem {
+export interface FiaPericopeCacheKey {
+  fiaLanguageCode: string;
   pericopeId: string;
+}
+
+export interface FiaAttachmentQueueItem extends FiaPericopeCacheKey {
   projectId: string;
   status: FiaAttachmentStatus;
   error?: string;
   enqueuedAt: number;
   completedAt?: number;
+}
+
+/** Drops pre-LQ-17 queue rows that lack fiaLanguageCode (pericope-only dedupe era). */
+function sanitizeFiaAttachmentQueue(queue: unknown): FiaAttachmentQueueItem[] {
+  if (!Array.isArray(queue)) return [];
+  return queue.filter(
+    (item): item is FiaAttachmentQueueItem =>
+      !!item &&
+      typeof item === 'object' &&
+      typeof (item as FiaAttachmentQueueItem).pericopeId === 'string' &&
+      typeof (item as FiaAttachmentQueueItem).fiaLanguageCode === 'string' &&
+      typeof (item as FiaAttachmentQueueItem).projectId === 'string'
+  );
 }
 
 // AsyncStorage keys for user preferences
@@ -301,12 +318,13 @@ export interface LocalState {
   enqueueFiaAttachment: (item: {
     pericopeId: string;
     projectId: string;
+    fiaLanguageCode: string;
   }) => void;
   updateFiaAttachment: (
-    pericopeId: string,
+    key: FiaPericopeCacheKey,
     update: Partial<FiaAttachmentQueueItem>
   ) => void;
-  removeFiaAttachment: (pericopeId: string) => void;
+  removeFiaAttachment: (key: FiaPericopeCacheKey) => void;
   clearCompletedFiaAttachments: () => void;
 
   // Invite members banner dismissal tracking (projectId -> timestamp)
@@ -682,32 +700,47 @@ export const useLocalStore = create<LocalState>()(
 
       // FIA attachment queue
       fiaAttachmentQueue: [],
-      enqueueFiaAttachment: ({ pericopeId, projectId }) =>
+      enqueueFiaAttachment: ({ pericopeId, projectId, fiaLanguageCode }) =>
         set((state) => {
-          if (state.fiaAttachmentQueue.some((i) => i.pericopeId === pericopeId))
+          if (
+            state.fiaAttachmentQueue.some(
+              (i) =>
+                i.pericopeId === pericopeId &&
+                i.fiaLanguageCode === fiaLanguageCode
+            )
+          ) {
             return state;
+          }
           return {
             fiaAttachmentQueue: [
               ...state.fiaAttachmentQueue,
               {
                 pericopeId,
                 projectId,
+                fiaLanguageCode,
                 status: 'pending' as const,
                 enqueuedAt: Date.now()
               }
             ]
           };
         }),
-      updateFiaAttachment: (pericopeId, update) =>
+      updateFiaAttachment: (key, update) =>
         set((state) => ({
           fiaAttachmentQueue: state.fiaAttachmentQueue.map((item) =>
-            item.pericopeId === pericopeId ? { ...item, ...update } : item
+            item.pericopeId === key.pericopeId &&
+            item.fiaLanguageCode === key.fiaLanguageCode
+              ? { ...item, ...update }
+              : item
           )
         })),
-      removeFiaAttachment: (pericopeId) =>
+      removeFiaAttachment: (key) =>
         set((state) => ({
           fiaAttachmentQueue: state.fiaAttachmentQueue.filter(
-            (i) => i.pericopeId !== pericopeId
+            (i) =>
+              !(
+                i.pericopeId === key.pericopeId &&
+                i.fiaLanguageCode === key.fiaLanguageCode
+              )
           )
         })),
       clearCompletedFiaAttachments: () =>
@@ -762,11 +795,23 @@ export const useLocalStore = create<LocalState>()(
           delete state.enableLanguoidLinkSuggestions;
           delete state.enableProjectLanguoidSuggestions;
         }
+        if ('fiaAttachmentQueue' in state) {
+          state.fiaAttachmentQueue = sanitizeFiaAttachmentQueue(
+            state.fiaAttachmentQueue
+          );
+        }
         return persistedState as LocalState;
       },
       onRehydrateStorage: () => async (state) => {
         console.log('rehydrating local store', state);
         if (state) {
+          const sanitizedQueue = sanitizeFiaAttachmentQueue(
+            state.fiaAttachmentQueue
+          );
+          if (sanitizedQueue.length !== state.fiaAttachmentQueue.length) {
+            useLocalStore.setState({ fiaAttachmentQueue: sanitizedQueue });
+          }
+
           state.setTheme(state.theme);
           // Validate and clamp VAD threshold if invalid
           if (

--- a/utils/languoidLookups.ts
+++ b/utils/languoidLookups.ts
@@ -78,6 +78,14 @@ export async function lookupFiaLanguageCode(
   return data.value;
 }
 
+export async function lookupFiaLanguageCodeForProject(
+  projectId: string
+): Promise<string | null> {
+  const sourceLanguoidId = await lookupSourceLanguoidId(projectId);
+  if (!sourceLanguoidId) return null;
+  return lookupFiaLanguageCode(sourceLanguoidId);
+}
+
 export async function lookupIso639_3(
   languoidId: string
 ): Promise<string | null> {

--- a/views/new/BibleAssetsView.tsx
+++ b/views/new/BibleAssetsView.tsx
@@ -124,6 +124,8 @@ import { AppConfig } from '@/db/supabase/AppConfig';
 import { useAssetsByQuest, useLocalAssetsByQuest } from '@/hooks/db/useAssets';
 import { useBlockedAssetsCount } from '@/hooks/useBlockedCount';
 import { useFiaPericopeSteps } from '@/hooks/useFiaPericopeSteps';
+import { useProjectFiaLanguageCode } from '@/hooks/useProjectFiaLanguageCode';
+import { isFiaPericopeCached } from '@/services/FiaAttachmentQueue';
 import { useQuestOffloadVerification } from '@/hooks/useQuestOffloadVerification';
 import { useHasUserReported } from '@/hooks/useReports';
 import { useUndoHistory } from '@/hooks/useUndoHistory';
@@ -817,6 +819,16 @@ export default function BibleAssetsView() {
     ? (fiaMetaExtracted?.pericopeId ?? null)
     : null;
 
+  const { fiaLanguageCode } = useProjectFiaLanguageCode(
+    fiaPericopeId ? projectId : undefined
+  );
+
+  const needsFiaRecache = Boolean(
+    fiaPericopeId &&
+      fiaLanguageCode &&
+      !isFiaPericopeCached(fiaLanguageCode, fiaPericopeId)
+  );
+
   // Fetch all FIA steps (only for FIA pericope quests)
   const { data: fiaStepsData, isLoading: fiaStepsLoading } =
     useFiaPericopeSteps(
@@ -825,18 +837,30 @@ export default function BibleAssetsView() {
     );
 
   // Auto-open FIA steps drawer once per quest per session.
-  // Once the user closes it, don't reopen (even after navigating to recording and back).
+  // Open immediately when guide content must be downloaded (e.g. post LQ-17 recache).
+  // When cached, open after data is ready. If the user dismissed the drawer, don't reopen
+  // unless content is missing and needs a fresh download.
   React.useEffect(() => {
-    if (
-      fiaPericopeId &&
-      questId &&
-      fiaStepsData &&
-      !fiaStepsLoading &&
-      !fiaDrawerDismissedQuests.has(questId)
-    ) {
+    if (!fiaPericopeId || !questId) return;
+
+    const dismissed = fiaDrawerDismissedQuests.has(questId);
+    if (dismissed && !needsFiaRecache) return;
+
+    if (needsFiaRecache) {
+      setShowFiaTextDrawer(true);
+      return;
+    }
+
+    if (fiaStepsData && !fiaStepsLoading) {
       setShowFiaTextDrawer(true);
     }
-  }, [fiaPericopeId, questId, fiaStepsData, fiaStepsLoading]);
+  }, [
+    fiaPericopeId,
+    questId,
+    needsFiaRecache,
+    fiaStepsData,
+    fiaStepsLoading
+  ]);
 
   // Build the ordered verse sequence for FIA pericopes (null for standard chapters)
   const pericopeSequence = React.useMemo<ChapterVerse[] | null>(() => {

--- a/views/new/BibleAssetsView.tsx
+++ b/views/new/BibleAssetsView.tsx
@@ -825,8 +825,8 @@ export default function BibleAssetsView() {
 
   const needsFiaRecache = Boolean(
     fiaPericopeId &&
-      fiaLanguageCode &&
-      !isFiaPericopeCached(fiaLanguageCode, fiaPericopeId)
+    fiaLanguageCode &&
+    !isFiaPericopeCached(fiaLanguageCode, fiaPericopeId)
   );
 
   // Fetch all FIA steps (only for FIA pericope quests)
@@ -854,13 +854,7 @@ export default function BibleAssetsView() {
     if (fiaStepsData && !fiaStepsLoading) {
       setShowFiaTextDrawer(true);
     }
-  }, [
-    fiaPericopeId,
-    questId,
-    needsFiaRecache,
-    fiaStepsData,
-    fiaStepsLoading
-  ]);
+  }, [fiaPericopeId, questId, needsFiaRecache, fiaStepsData, fiaStepsLoading]);
 
   // Build the ordered verse sequence for FIA pericopes (null for standard chapters)
   const pericopeSequence = React.useMemo<ChapterVerse[] | null>(() => {


### PR DESCRIPTION
## Summary

The app saved FIA guide text under the pericope id alone (`mrk-p1`). The download queue treated `mrk-p1` as one job no matter the language. Switch projects and English can still show French.

Reads and writes now use `(fiaLanguageCode, pericopeId)`. Files land at `fia_attachments/{code}/{pericopeId}/response.json`. The queue and hooks use the same pair.

## What shipped

* Cache key is `fiaLanguageCode`, not `projectId`. Same as the edge API. Two English projects share one on-disk cache.
* Old paths like `fia_attachments/mrk-p1/` stay on disk. This PR does not read them. Open the pericope again and it fetches fresh content.
* `local-store` stays on persist **version 1**. On hydrate we remove queue rows without `fiaLanguageCode`. Old `completed` rows used to block English downloads. We did not bump the persist version. Without `migrate`, Zustand can drop the whole saved store.
* Images and audio still cache by URL.
* Scope is cache, queue, and call sites. Orphan folder cleanup is later.
* Auto-open the FIA drawer when guide content is not cached (migration UX; may remove later).

After you update, each pericope downloads again the first time you open it.

## Test plan

- [X] French FIA project → open a pericope → French guide
- [X] English FIA project → same pericope → English guide
- [X] Back to French → same pericope → French guide
- [X] Existing pericope, no cache → drawer opens with download UI

## Follow-up

Delete orphan folders: `fia_attachments/{pericopeId}/` with no language segment in the path. Do not move them into `fra/` or `eng/`. The language is unknown.

Later: delete on launch after a release window, or add "Clear FIA offline cache" in settings. Track under [Rock: Content Offloading](https://linear.app/frontierrandd/project/rock-content-offloading-0b5ea1cc75dc/overview).