### PR TITLE
fix(supabase): add AUTH_SITE_URL to edge runtime secrets (main)

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -323,6 +323,7 @@ policy = "oneshot"
 inspector_port = 8083
 
 [edge_runtime.secrets]
+AUTH_SITE_URL = "env(AUTH_SITE_URL)"
 SEND_EMAIL_HOOK_SECRET = "env(SEND_EMAIL_HOOK_SECRET)"
 RESEND_API_KEY = "env(RESEND_API_KEY)"
 RESEND_WEBHOOK_SECRET = "env(RESEND_WEBHOOK_SECRET)"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Cherry-pick of `96b22a35` from `dev` (#895) onto `main`.

Adds `AUTH_SITE_URL` to `[edge_runtime.secrets]` in `supabase/config.toml` so production edge functions receive the variable (fixes `undefined` in `send-email`).

## Cherry-pick

```
96b22a35b7953fe6901989e97f11b0be7f75aeb8
```

Merged to `dev` via #895.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f018f545-86a4-4b83-bacf-1571e99f30ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f018f545-86a4-4b83-bacf-1571e99f30ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

