### PR TITLE
Disable background audio playback to resolve Play Console FGS declaration (LQ-46)

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -137,7 +137,7 @@ export default ({ config }: ConfigContext): ExpoConfig =>
       // TODO: migrate existing localization to expo-localization
       'expo-localization',
       'expo-asset',
-      'expo-audio',
+      ['expo-audio', { enableBackgroundPlayback: false }],
       'expo-image',
       [
         'expo-build-properties',

--- a/components/AudioPlayer.tsx
+++ b/components/AudioPlayer.tsx
@@ -50,7 +50,7 @@ const AudioPlayer: React.FC<AudioPlayerProps> = ({
       await setAudioModeAsync({
         allowsRecording: false,
         playsInSilentMode: true,
-        shouldPlayInBackground: true
+        shouldPlayInBackground: false
       });
     };
 

--- a/contexts/AudioContext.tsx
+++ b/contexts/AudioContext.tsx
@@ -317,7 +317,7 @@ export function AudioProvider({ children }: { children: React.ReactNode }) {
     await setAudioModeAsync({
       allowsRecording: false,
       playsInSilentMode: true,
-      shouldPlayInBackground: true
+      shouldPlayInBackground: false
     });
 
     // Resolve through file cache (downloads remote files on first access, serves local copy thereafter)

--- a/hooks/usePlayAllAudioController.ts
+++ b/hooks/usePlayAllAudioController.ts
@@ -91,7 +91,7 @@ async function ensureAudioPlaybackMode(): Promise<void> {
   await setAudioModeAsync({
     allowsRecording: false,
     playsInSilentMode: true,
-    shouldPlayInBackground: true
+    shouldPlayInBackground: false
   });
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **Option B** from LQ-46: in-app listening only. Audio stops when the app goes to the background, so Android builds no longer need `FOREGROUND_SERVICE` / `FOREGROUND_SERVICE_MEDIA_PLAYBACK` and the Play Console foreground service declaration can clear without a demo video.

## Changes

- `app.config.ts`: configure `expo-audio` with `enableBackgroundPlayback: false`
- `contexts/AudioContext.tsx`: `shouldPlayInBackground: false`
- `components/AudioPlayer.tsx`: `shouldPlayInBackground: false`
- `hooks/usePlayAllAudioController.ts`: `shouldPlayInBackground: false`

## Next steps after merge

1. Ship a new Android build (prebuild/rebuild required so the manifest drops FGS permissions)
2. Confirm Play Console no longer flags the overdue foreground service declaration

## Re-enabling background playback later

If users request it, revert these settings, ship a new build, and complete Option A (Play Console form + demo video).
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LQ-46](https://linear.app/frontierrandd/issue/LQ-46/resolve-play-console-foreground-service-declaration-declare-or-disable)

<div><a href="https://cursor.com/agents/bc-f1b854fc-2aa1-4e0f-82dc-d961cf054267"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f1b854fc-2aa1-4e0f-82dc-d961cf054267"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

