### PR TITLE
Caleb/patch nav bar hides quests

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -218,7 +218,7 @@ export default ({ config }: ConfigContext): ExpoConfig =>
     owner: 'eten-genesis',
     name: getAppName(appVariant),
     slug: 'langquest',
-    version: '2.2.2',
+    version: '2.2.4',
     orientation: 'portrait',
     icon: iconLight,
     scheme: getScheme(appVariant),

--- a/app.config.ts
+++ b/app.config.ts
@@ -2,6 +2,7 @@ import type { ConfigPlugin } from '@expo/config-plugins';
 import {
   AndroidConfig,
   withAndroidManifest,
+  withAppBuildGradle,
   withGradleProperties,
   withPodfileProperties
 } from '@expo/config-plugins';
@@ -17,6 +18,42 @@ const withGradleMemory: ConfigPlugin = (config) =>
         ? { ...item, value: '-Xmx4096m -XX:MaxMetaspaceSize=1536m' }
         : item
     );
+    return c;
+  });
+
+// `debugOptimized` is not in RN's default debuggableVariants list, so those
+// APKs bake JS into the binary. Daily `npm run android` uses that variant;
+// without this, Metro edits are ignored whenever the app falls back to the
+// embedded bundle. android/ is gitignored and remade by prebuild --clean.
+const withDebuggableVariants: ConfigPlugin = (config) =>
+  withAppBuildGradle(config, (c) => {
+    if (c.modResults.language !== 'groovy') return c;
+
+    const line =
+      '    debuggableVariants = ["debug", "debugOptimized"]';
+    const contents = c.modResults.contents;
+
+    if (contents.includes('debuggableVariants = ["debug", "debugOptimized"]')) {
+      return c;
+    }
+
+    if (/^\s*\/\/\s*debuggableVariants\s*=/m.test(contents)) {
+      c.modResults.contents = contents.replace(
+        /^\s*\/\/\s*debuggableVariants\s*=.*$/m,
+        line
+      );
+    } else if (/\/\*\s*Variants\s*\*\//.test(contents)) {
+      c.modResults.contents = contents.replace(
+        /\/\*\s*Variants\s*\*\//,
+        `/* Variants */\n${line}`
+      );
+    } else {
+      c.modResults.contents = contents.replace(
+        /autolinkLibrariesWithApp\(\)/,
+        `${line.trim()}\n\n    autolinkLibrariesWithApp()`
+      );
+    }
+
     return c;
   });
 
@@ -187,7 +224,10 @@ export default ({ config }: ConfigContext): ExpoConfig =>
     icon: iconLight,
     scheme: getScheme(appVariant),
     userInterfaceStyle: 'automatic',
-    buildCacheProvider: 'eas',
+    // TEMP: disabled so local `expo run:android` actually builds from this tree
+    // instead of downloading a fingerprint-matched EAS APK with stale JS.
+    // Re-enable after safe-area debugging: buildCacheProvider: 'eas',
+    // buildCacheProvider: 'eas',
     ios: {
       icon: {
         light: iconLight,
@@ -285,7 +325,8 @@ export default ({ config }: ConfigContext): ExpoConfig =>
       ['expo-alternate-app-icons', getAppearanceIcons()],
       ['testflight-dev-deploy', { enabled: appVariant === 'development' }],
       'posthog-react-native/expo',
-      withGradleMemory
+      withGradleMemory,
+      withDebuggableVariants
     ],
     experiments: {
       typedRoutes: true,

--- a/app.config.ts
+++ b/app.config.ts
@@ -29,8 +29,7 @@ const withDebuggableVariants: ConfigPlugin = (config) =>
   withAppBuildGradle(config, (c) => {
     if (c.modResults.language !== 'groovy') return c;
 
-    const line =
-      '    debuggableVariants = ["debug", "debugOptimized"]';
+    const line = '    debuggableVariants = ["debug", "debugOptimized"]';
     const contents = c.modResults.contents;
 
     if (contents.includes('debuggableVariants = ["debug", "debugOptimized"]')) {

--- a/components/ArrayInsertionList.tsx
+++ b/components/ArrayInsertionList.tsx
@@ -1,7 +1,6 @@
 // theme colors no longer needed after removing overlay
 import { useHaptic } from '@/hooks/useHaptic';
-import type { LegendListRef } from '@legendapp/list';
-import { LegendList } from '@legendapp/list';
+import { LegendList, type LegendListRef } from '@/components/ui/legend-list';
 import React from 'react';
 import type {
   LayoutChangeEvent,

--- a/components/DrawerLegendList.tsx
+++ b/components/DrawerLegendList.tsx
@@ -1,6 +1,6 @@
+import type { LegendListProps, LegendListRef } from '@/components/ui/legend-list';
+import { LegendList } from '@/components/ui/legend-list';
 import { useBottomSheetScrollableCreator } from '@gorhom/bottom-sheet';
-import type { LegendListProps, LegendListRef } from '@legendapp/list';
-import { LegendList } from '@legendapp/list';
 import React from 'react';
 import type { StyleProp, ViewStyle } from 'react-native';
 
@@ -60,6 +60,8 @@ export function DrawerLegendList<T>({
       contentContainerStyle={contentContainerStyle}
       renderScrollComponent={BottomSheetScrollable}
       {...(legendListProps as LegendListProps<T>)}
+      // Sheets manage their own chrome; don't double-count the nav bar.
+      ignoreSafeBottom
     />
   );
 }

--- a/components/DrawerLegendList.tsx
+++ b/components/DrawerLegendList.tsx
@@ -1,4 +1,7 @@
-import type { LegendListProps, LegendListRef } from '@/components/ui/legend-list';
+import type {
+  LegendListProps,
+  LegendListRef
+} from '@/components/ui/legend-list';
 import { LegendList } from '@/components/ui/legend-list';
 import { useBottomSheetScrollableCreator } from '@gorhom/bottom-sheet';
 import React from 'react';

--- a/components/ExportQuestList.tsx
+++ b/components/ExportQuestList.tsx
@@ -12,7 +12,7 @@ import {
   shareExport
 } from '@/utils/exportUtils';
 import RNAlert from '@blazejkustra/react-native-alert';
-import { LegendList } from '@legendapp/list';
+import { LegendList } from '@/components/ui/legend-list';
 import { Download, Info, Share2Icon } from 'lucide-react-native';
 import React from 'react';
 import {

--- a/components/RecordingSelectionList.tsx
+++ b/components/RecordingSelectionList.tsx
@@ -11,8 +11,7 @@
  * - Supports lazy rendering with data + renderItem
  */
 
-import type { LegendListRef } from '@legendapp/list';
-import { LegendList } from '@legendapp/list';
+import { LegendList, type LegendListRef } from '@/components/ui/legend-list';
 import { ArrowDownNarrowWide, Mic } from 'lucide-react-native';
 import React from 'react';
 import type { NativeScrollEvent, NativeSyntheticEvent } from 'react-native';

--- a/components/ui/legend-list.tsx
+++ b/components/ui/legend-list.tsx
@@ -45,13 +45,11 @@ function LegendListInner<T>(
       {...rest}
       ListFooterComponent={() => (
         <View>
-          {ListFooterComponent ? (
-            React.isValidElement(ListFooterComponent) ? (
-              ListFooterComponent
-            ) : (
-              React.createElement(ListFooterComponent as React.ComponentType)
-            )
-          ) : null}
+          {ListFooterComponent
+            ? React.isValidElement(ListFooterComponent)
+              ? ListFooterComponent
+              : React.createElement(ListFooterComponent as React.ComponentType)
+            : null}
           {spacerHeight > 0 ? <View style={{ height: spacerHeight }} /> : null}
         </View>
       )}

--- a/components/ui/legend-list.tsx
+++ b/components/ui/legend-list.tsx
@@ -1,0 +1,64 @@
+import {
+  LegendList as LegendListBase,
+  type LegendListProps,
+  type LegendListRef
+} from '@legendapp/list';
+import React from 'react';
+import { View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+export type { LegendListProps, LegendListRef };
+
+type AppLegendListProps<T> = LegendListProps<T> & {
+  /** Extra clearance above the system inset (e.g. for a FAB). */
+  bottomExtra?: number;
+  /**
+   * Skip the system bottom inset (e.g. list already sits above a padded
+   * footer, or lives inside a sheet that handles safe area itself).
+   */
+  ignoreSafeBottom?: boolean;
+};
+
+/**
+ * App LegendList: keeps the last row clear of the Android nav bar / iOS home
+ * indicator unless `ignoreSafeBottom` is set.
+ *
+ * Import from `@/components/ui/legend-list` — not `@legendapp/list` (ESLint-enforced).
+ * LegendList ignores contentContainerStyle.paddingBottom when sizing scroll
+ * content; a footer spacer is the reliable inset mechanism.
+ */
+function LegendListInner<T>(
+  {
+    bottomExtra = 0,
+    ignoreSafeBottom = false,
+    ListFooterComponent,
+    ...rest
+  }: AppLegendListProps<T>,
+  ref: React.Ref<LegendListRef>
+) {
+  const { bottom } = useSafeAreaInsets();
+  const spacerHeight = (ignoreSafeBottom ? 0 : bottom) + bottomExtra;
+
+  return (
+    <LegendListBase
+      ref={ref}
+      {...rest}
+      ListFooterComponent={() => (
+        <View>
+          {ListFooterComponent ? (
+            React.isValidElement(ListFooterComponent) ? (
+              ListFooterComponent
+            ) : (
+              React.createElement(ListFooterComponent as React.ComponentType)
+            )
+          ) : null}
+          {spacerHeight > 0 ? <View style={{ height: spacerHeight }} /> : null}
+        </View>
+      )}
+    />
+  );
+}
+
+export const LegendList = React.forwardRef(LegendListInner) as <T>(
+  props: AppLegendListProps<T> & { ref?: React.Ref<LegendListRef> }
+) => React.ReactElement;

--- a/eslint.config.mts
+++ b/eslint.config.mts
@@ -80,9 +80,28 @@ export default defineConfig(
       '@typescript-eslint/no-non-null-assertion': 'off',
       '@typescript-eslint/prefer-nullish-coalescing': 'off',
       'import/consistent-type-specifier-style': ['error', 'prefer-top-level'],
+      'no-restricted-imports': [
+        'error',
+        {
+          paths: [
+            {
+              name: '@legendapp/list',
+              message:
+                'Import from `@/components/ui/legend-list` so lists clear the Android nav bar / home indicator.'
+            }
+          ]
+        }
+      ],
       ...reactPlugin.configs['jsx-runtime'].rules,
       ...hooksPlugin.configs.recommended.rules,
       'react-compiler/react-compiler': 'error'
+    }
+  },
+  {
+    // Only the wrapper may import the upstream package.
+    files: ['components/ui/legend-list.tsx'],
+    rules: {
+      'no-restricted-imports': 'off'
     }
   }
 );

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "langquest",
   "main": "expo-router/entry",
-  "version": "2.2.2",
+  "version": "2.2.4",
   "scripts": {
     "start": "expo start --dev-client",
     "start:offline:android": "npm run start -- --localhost --android",

--- a/services/posthog.ts
+++ b/services/posthog.ts
@@ -72,10 +72,14 @@ export const syncPostHogIdentity = async () => {
   }
 };
 
-/** Set the authenticated user id (or null). Re-syncs identity when consent allows. */
-export const setPostHogUserId = (userId: string | null) => {
-  pendingPostHogUserId = userId;
-  void syncPostHogIdentity();
+/**
+ * Intentionally a no-op: identifying PostHog persons by auth user id is on
+ * hold until GDPR requirements are sorted out. Restore the body below to
+ * re-enable.
+ */
+export const setPostHogUserId = (_userId: string | null) => {
+  // pendingPostHogUserId = _userId;
+  // void syncPostHogIdentity();
 };
 
 const changeAnalyticsState = async (newState: boolean) => {

--- a/services/posthog.web.ts
+++ b/services/posthog.web.ts
@@ -70,9 +70,14 @@ export const syncPostHogIdentity = () => {
   }
 };
 
-export const setPostHogUserId = (userId: string | null) => {
-  pendingPostHogUserId = userId;
-  syncPostHogIdentity();
+/**
+ * Intentionally a no-op: identifying PostHog persons by auth user id is on
+ * hold until GDPR requirements are sorted out. Restore the body below to
+ * re-enable.
+ */
+export const setPostHogUserId = (_userId: string | null) => {
+  // pendingPostHogUserId = _userId;
+  // syncPostHogIdentity();
 };
 
 function changeAnalyticsState(newState: boolean) {

--- a/views/new/BibleBookList.tsx
+++ b/views/new/BibleBookList.tsx
@@ -7,7 +7,7 @@ import { useBibleBookNameGetter } from '@/hooks/useBibleBookName';
 import { useLocalization } from '@/hooks/useLocalization';
 import { BOOK_ICON_MAP } from '@/utils/BOOK_GRAPHICS';
 import { cn, useThemeColor } from '@/utils/styleUtils';
-import { LegendList } from '@legendapp/list';
+import { LegendList } from '@/components/ui/legend-list';
 import { PlusCircleIcon } from 'lucide-react-native';
 import { Image } from 'expo-image';
 import React from 'react';
@@ -114,7 +114,7 @@ export function BibleBookList({
   ];
 
   return (
-    <View className="mb-safe flex-1 gap-6">
+    <View className="flex-1 gap-6">
       <LegendList
         data={allBooks}
         keyExtractor={(item) => (typeof item === 'string' ? item : item.id)}
@@ -122,9 +122,9 @@ export function BibleBookList({
         estimatedItemSize={140}
         columnWrapperStyle={{ gap: gap }}
         contentContainerStyle={{
-          paddingHorizontal: padding,
-          paddingBottom: 24
+          paddingHorizontal: padding
         }}
+        bottomExtra={24}
         recycleItems
         renderItem={({ item }) => renderBookButton(item, item.testament)}
         StickyHeaderComponent={() => (
@@ -169,9 +169,9 @@ export function BibleBookListSkeleton() {
         estimatedItemSize={140}
         columnWrapperStyle={{ gap: gap }}
         contentContainerStyle={{
-          paddingHorizontal: padding,
-          paddingBottom: 24
+          paddingHorizontal: padding
         }}
+        bottomExtra={24}
         recycleItems
         renderItem={() => (
           <Skeleton

--- a/views/new/BibleChapterList.tsx
+++ b/views/new/BibleChapterList.tsx
@@ -39,7 +39,7 @@ import { bulkDownloadQuest } from '@/utils/bulkDownload';
 import { formatRelativeDate } from '@/utils/dateUtils';
 import { cn, useThemeColor } from '@/utils/styleUtils';
 import RNAlert from '@blazejkustra/react-native-alert';
-import { LegendList } from '@legendapp/list';
+import { LegendList } from '@/components/ui/legend-list';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { Image } from 'expo-image';
 import {

--- a/views/new/FiaBookList.tsx
+++ b/views/new/FiaBookList.tsx
@@ -12,7 +12,7 @@ import type { FiaBook } from '@/hooks/useFiaBooks';
 import { useLocalization } from '@/hooks/useLocalization';
 import { BOOK_ICON_MAP } from '@/utils/BOOK_GRAPHICS';
 import { cn, useThemeColor } from '@/utils/styleUtils';
-import { LegendList } from '@legendapp/list';
+import { LegendList } from '@/components/ui/legend-list';
 import { BookOpenIcon, PlusCircleIcon } from 'lucide-react-native';
 import { Image } from 'expo-image';
 import React from 'react';
@@ -171,7 +171,7 @@ export function FiaBookList({
   };
 
   return (
-    <View className="mb-safe flex-1 gap-6">
+    <View className="flex-1 gap-6">
       <LegendList
         data={sortedBooks}
         keyExtractor={(item) => item.id}
@@ -179,9 +179,9 @@ export function FiaBookList({
         estimatedItemSize={140}
         columnWrapperStyle={{ gap }}
         contentContainerStyle={{
-          paddingHorizontal: padding,
-          paddingBottom: 24
+          paddingHorizontal: padding
         }}
+        bottomExtra={24}
         recycleItems
         renderItem={({ item }) => renderBookButton(item)}
       />
@@ -217,9 +217,9 @@ export function FiaBookListSkeleton() {
         estimatedItemSize={140}
         columnWrapperStyle={{ gap }}
         contentContainerStyle={{
-          paddingHorizontal: padding,
-          paddingBottom: 24
+          paddingHorizontal: padding
         }}
+        bottomExtra={24}
         recycleItems
         renderItem={() => (
           <Skeleton

--- a/views/new/FiaPericopeList.tsx
+++ b/views/new/FiaPericopeList.tsx
@@ -39,7 +39,7 @@ import { bulkDownloadQuest } from '@/utils/bulkDownload';
 import { BOOK_ICON_MAP } from '@/utils/BOOK_GRAPHICS';
 import { formatRelativeDate } from '@/utils/dateUtils';
 import { cn, useThemeColor } from '@/utils/styleUtils';
-import { LegendList } from '@legendapp/list';
+import { LegendList } from '@/components/ui/legend-list';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { Image } from 'expo-image';
 import {

--- a/views/new/NextGenAssetsView.tsx
+++ b/views/new/NextGenAssetsView.tsx
@@ -34,7 +34,7 @@ import { useUserPermissions } from '@/hooks/useUserPermissions';
 import { useLocalStore } from '@/store/localStore';
 import { SHOW_DEV_ELEMENTS } from '@/utils/featureFlags';
 import RNAlert from '@blazejkustra/react-native-alert';
-import { LegendList } from '@legendapp/list';
+import { LegendList } from '@/components/ui/legend-list';
 import { useKeepAwake } from 'expo-keep-awake';
 import { Stack } from 'expo-router';
 import {
@@ -75,10 +75,10 @@ import { useHybridData } from './useHybridData';
 
 import { AssetListSkeleton } from '@/components/AssetListSkeleton';
 import { ExportButton } from '@/components/ExportButton';
-import { PublishQuestButton } from '@/components/PublishQuestButton';
 import { ModalDetails } from '@/components/ModalDetails';
 import { ReportModal } from '@/components/NewReportModal';
 import { PrivateAccessGate } from '@/components/PrivateAccessGate';
+import { PublishQuestButton } from '@/components/PublishQuestButton';
 import { QuestOffloadVerificationDrawer } from '@/components/QuestOffloadVerificationDrawer';
 import { run as runAssetGarbageCollector } from '@/database_services/assetGarbageCollectorService';
 import {

--- a/views/new/NextGenProjectsView.tsx
+++ b/views/new/NextGenProjectsView.tsx
@@ -17,7 +17,7 @@ import {
   useSimpleHybridInfiniteData
 } from '@/views/new/useHybridData';
 import RNAlert from '@blazejkustra/react-native-alert';
-import { LegendList } from '@legendapp/list';
+import { LegendList } from '@/components/ui/legend-list';
 import {
   and,
   desc,
@@ -910,7 +910,7 @@ export default function NextGenProjectsView() {
                     ? `invite-${item.projectId}-${activeTab}`
                     : `project-${item.project.id}-${activeTab}`
                 }
-                contentContainerClassName="pb-8"
+                bottomExtra={32}
                 recycleItems
                 estimatedItemSize={175}
                 maintainVisibleContentPosition

--- a/views/new/NextGenTranslationsList.tsx
+++ b/views/new/NextGenTranslationsList.tsx
@@ -9,11 +9,12 @@ import { useAttachmentStates } from '@/hooks/useAttachmentStates';
 import { useBlockedTranslationsCount } from '@/hooks/useBlockedCount';
 import { useLocalization } from '@/hooks/useLocalization';
 import type { MembershipRole } from '@/hooks/useUserPermissions';
+import { useLocalStore } from '@/store/localStore';
 import type { SortOrder, WithSource } from '@/utils/dbUtils';
 import { SHOW_DEV_ELEMENTS } from '@/utils/featureFlags';
 import { getLocalUri } from '@/utils/fileUtils';
 import { getThemeColor } from '@/utils/styleUtils';
-import { LegendList } from '@legendapp/list';
+import { LegendList } from '@/components/ui/legend-list';
 import {
   ArrowDownWideNarrowIcon,
   ArrowUpNarrowWideIcon,
@@ -22,10 +23,9 @@ import {
   ShieldOffIcon,
   ThumbsUpIcon
 } from 'lucide-react-native';
-import { useLocalStore } from '@/store/localStore';
 import React, { useMemo, useState } from 'react';
-import { useShallow } from 'zustand/react/shallow';
 import { ActivityIndicator, View } from 'react-native';
+import { useShallow } from 'zustand/react/shallow';
 import NextGenTranslationModal from './NextGenTranslationModalAlt';
 
 interface NextGenTranslationsListProps {

--- a/views/new/QuestListView.tsx
+++ b/views/new/QuestListView.tsx
@@ -6,7 +6,7 @@ import { system } from '@/db/powersync/system';
 import { useLocalization } from '@/hooks/useLocalization';
 import { useLocalStore } from '@/store/localStore';
 import type { WithSource } from '@/utils/dbUtils';
-import { LegendList } from '@legendapp/list';
+import { LegendList } from '@/components/ui/legend-list';
 import { and, eq, like, or } from 'drizzle-orm';
 import React from 'react';
 import { ActivityIndicator, View } from 'react-native';


### PR DESCRIPTION
Wrapped LegendList in a safety wrapper to prevent bottom row of list from hiding behind android navigation bar.

Also, uncovered an issue while running npm run android and noticed it wasn't applying any of my TS changes being made. 

Apparently this was due to the --variant debugOptimized flag in the npm run android script, combined with the debuggableVariants setting in android/app/build.gradle

In other words, normally when we build android and test, buildCacheProvider: 'eas' in app.config.ts looks at eas to see if there's already a build we can use so we don't waste time rebuilding every time we run npm run android.

The local Metro server then applies overtop of this any TS changes we make.

However, the --variant debugOptimize flag wrapped up all the TS into the APK build (to make the dev build feel more like the native build, which is desired) and locked me out of seeing the TS changes I was making.

To resolve this, in android/app/build.gradle, the debuggableVariants must include "debugOptimized":

debuggableVariants = ["debug", "debugOptimized"]

Unfortunately, whenever there's a clean rebuild (e.g., npm run clean-rebuild:android) the android folder (and the changes made in build.gradle) are wiped out.

To avoid this problem, there's now a script in app.config.ts that will rewrite these changes to build.gradle whenever a clean rebuild is done.

This should now allow us to have an optimized build while ensuring we see the latest TS changes we're making (for Android). I've testing the gradle.build value change and the script for rewriting the change after a clean rebuild and everything seems to be working. 