### PR TITLE
Bump version, remove posthog identify()

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -182,7 +182,7 @@ export default ({ config }: ConfigContext): ExpoConfig =>
     owner: 'eten-genesis',
     name: getAppName(appVariant),
     slug: 'langquest',
-    version: '2.2.2',
+    version: '2.2.4',
     orientation: 'portrait',
     icon: iconLight,
     scheme: getScheme(appVariant),

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "langquest",
   "main": "expo-router/entry",
-  "version": "2.2.2",
+  "version": "2.2.4",
   "scripts": {
     "start": "expo start --dev-client",
     "start:offline:android": "npm run start -- --localhost --android",

--- a/services/posthog.ts
+++ b/services/posthog.ts
@@ -72,10 +72,14 @@ export const syncPostHogIdentity = async () => {
   }
 };
 
-/** Set the authenticated user id (or null). Re-syncs identity when consent allows. */
-export const setPostHogUserId = (userId: string | null) => {
-  pendingPostHogUserId = userId;
-  void syncPostHogIdentity();
+/**
+ * Intentionally a no-op: identifying PostHog persons by auth user id is on
+ * hold until GDPR requirements are sorted out. Restore the body below to
+ * re-enable.
+ */
+export const setPostHogUserId = (_userId: string | null) => {
+  // pendingPostHogUserId = _userId;
+  // void syncPostHogIdentity();
 };
 
 const changeAnalyticsState = async (newState: boolean) => {

--- a/services/posthog.web.ts
+++ b/services/posthog.web.ts
@@ -70,9 +70,14 @@ export const syncPostHogIdentity = () => {
   }
 };
 
-export const setPostHogUserId = (userId: string | null) => {
-  pendingPostHogUserId = userId;
-  syncPostHogIdentity();
+/**
+ * Intentionally a no-op: identifying PostHog persons by auth user id is on
+ * hold until GDPR requirements are sorted out. Restore the body below to
+ * re-enable.
+ */
+export const setPostHogUserId = (_userId: string | null) => {
+  // pendingPostHogUserId = _userId;
+  // syncPostHogIdentity();
 };
 
 function changeAnalyticsState(newState: boolean) {


### PR DESCRIPTION
- Bump version higher so we avoid decoder key sourcemap conflicts with posthog
- Deactivate identify() for posthog (we still need to sort out GDPR stuff)