### PR TITLE
stop maestro user reset/sign-in conflict

### DIFF
--- a/.maestro/api.js
+++ b/.maestro/api.js
@@ -68,11 +68,7 @@ function createConfirmedUser(email, password) {
       'Email is required and must be a non-empty string. Received: ' + email
     );
   }
-  if (
-    !password ||
-    typeof password !== 'string' ||
-    password.length < 6
-  ) {
+  if (!password || typeof password !== 'string' || password.length < 6) {
     throw new Error(
       'Password is required and must be at least 6 characters. Received: ' +
         password
@@ -80,7 +76,9 @@ function createConfirmedUser(email, password) {
   }
 
   const username =
-    'maestro_' + Date.now().toString(36) + Math.random().toString(36).slice(2, 6);
+    'maestro_' +
+    Date.now().toString(36) +
+    Math.random().toString(36).slice(2, 6);
 
   console.log('Creating confirmed user:', email);
 

--- a/.maestro/api.js
+++ b/.maestro/api.js
@@ -62,6 +62,57 @@ function getUserByEmail(email) {
   return matchingUser;
 }
 
+function createConfirmedUser(email, password) {
+  if (!email || typeof email !== 'string' || email.trim() === '') {
+    throw new Error(
+      'Email is required and must be a non-empty string. Received: ' + email
+    );
+  }
+  if (
+    !password ||
+    typeof password !== 'string' ||
+    password.length < 6
+  ) {
+    throw new Error(
+      'Password is required and must be at least 6 characters. Received: ' +
+        password
+    );
+  }
+
+  const username =
+    'maestro_' + Date.now().toString(36) + Math.random().toString(36).slice(2, 6);
+
+  console.log('Creating confirmed user:', email);
+
+  const createResponse = http.post(supabaseUrl + '/auth/v1/admin/users', {
+    headers: getDefaultHeaders(),
+    body: JSON.stringify({
+      email: email,
+      password: password,
+      email_confirm: true,
+      user_metadata: {
+        username: username,
+        terms_accepted: true,
+        terms_accepted_at: new Date().toISOString()
+      }
+    })
+  });
+
+  console.log('Create user response status:', createResponse.status);
+  console.log('Create user response body:', createResponse.body);
+
+  if (createResponse.status !== 200) {
+    throw new Error(
+      'Failed to create user: ' +
+        createResponse.status +
+        ' ' +
+        createResponse.body
+    );
+  }
+
+  return JSON.parse(createResponse.body);
+}
+
 function deleteUser(email) {
   const user = getUserByEmail(email);
   console.log('Found user ID:', user.id);
@@ -238,8 +289,19 @@ function deleteProject(projectName) {
   return deleteResponse;
 }
 
+function deleteUserIfExists(email) {
+  try {
+    return deleteUser(email);
+  } catch (error) {
+    console.log('deleteUserIfExists skipped:', error);
+    return null;
+  }
+}
+
 output.api = {
+  createConfirmedUser,
   deleteUser,
+  deleteUserIfExists,
   generatePasswordResetLink,
   deleteProject,
   updateUserPassword

--- a/.maestro/flows/reset-password.yaml
+++ b/.maestro/flows/reset-password.yaml
@@ -2,26 +2,25 @@ appId: ${MAESTRO_APP_ID}
 onFlowStart:
   - runScript: ../api.js
 onFlowComplete:
-  # Always restore so a failed run cannot leave the shared test user on the
-  # random password (which would break sign-in.yaml and the next reset).
-  - evalScript: ${output.api.updateUserPassword(MAESTRO_TEST_EMAIL, MAESTRO_TEST_PASSWORD)}
+  # Throwaway user — never touch MAESTRO_TEST_EMAIL (sign-in.yaml / the other OS).
+  - evalScript: ${output.api.deleteUserIfExists(output.resetEmail)}
 ---
 # Reset Password Test Flow
-# This test covers the complete password reset flow:
-# 1. Generate reset link directly via admin API (no email checking needed)
-# 2. Open reset link (deep link)
-# 3. Enter a random new password (must differ from the current one)
-# 4. Verify success
-# 5. Restore the original password (onFlowComplete) for sign-in.yaml / next run
+# 1. Create a throwaway confirmed user (Android and iOS must not share one)
+# 2. Generate reset link via admin API
+# 3. Open reset link (deep link)
+# 4. Enter a random new password
+# 5. Verify the user is logged in
+# 6. Delete the throwaway user
 #
 # Usage: maestro test -e MAESTRO_APP_ID=com.etengenesis.langquest.preview reset-password.yaml
-# The scheme will be automatically determined from MAESTRO_APP_ID (e.g., langquest-preview://reset-password)
 
+- evalScript: ${output.resetEmail = faker.internet().emailAddress()}
+- evalScript: ${output.initialPassword = "reset-init-" + Date.now() + "-" + Math.random().toString(36).slice(2, 8)}
 - evalScript: ${output.newPassword = "reset-" + Date.now() + "-" + Math.random().toString(36).slice(2, 10)}
+- evalScript: ${output.api.createConfirmedUser(output.resetEmail, output.initialPassword)}
+- evalScript: ${output.resetLink = output.api.generatePasswordResetLink(output.resetEmail)}
 
-- evalScript: ${output.resetLink = output.api.generatePasswordResetLink(MAESTRO_TEST_EMAIL)}
-
-# Step 2: Launch app and open the reset link
 - runFlow:
     file: _launch-and-onboard.yaml
 - openLink:
@@ -33,21 +32,18 @@ onFlowComplete:
       platform: iOS
     file: _ios-dismiss-safari-bookmark-popover.yaml
 
-# Handle the "Open this page in" system dialog (iOS style 1)
 - runFlow:
     when:
       visible: 'Open this page in.*'
     commands:
       - tapOn: Open
 
-# Handle the "Open in" system dialog (iOS style 2)
 - runFlow:
     when:
       visible: 'Open in.*'
     commands:
       - tapOn: Open
 
-# Step 3: Enter new password on reset password screen
 - assertVisible: Create New Password
 - tapOn: New Password
 - inputText: ${output.newPassword}
@@ -57,15 +53,37 @@ onFlowComplete:
     point: 95%,30%
 - tapOn: Update Password
 
-# Wait for and verify success alert
-- assertVisible: Success
-- tapOn: OK
+# Success alert can auto-dismiss after the recovery session becomes a normal login.
+- runFlow:
+    when:
+      visible: Success
+    commands:
+      - tapOn: OK
 
-# Verify the user can navigate and reach the profile page (being logged in)
-- tapOn:
-    id: app-drawer-menu-button
-- tapOn: Profile
-- assertVisible:
-    text: Profile
-    above:
-      text: ${MAESTRO_TEST_EMAIL}
+# Recovery login sometimes lands on Profile already. Don't require the drawer then.
+- runFlow:
+    when:
+      visible:
+        text: ${output.resetEmail}
+    commands:
+      - assertVisible:
+          text: Profile
+          above:
+            text: ${output.resetEmail}
+
+- runFlow:
+    when:
+      notVisible:
+        text: ${output.resetEmail}
+    commands:
+      - extendedWaitUntil:
+          visible:
+            id: app-drawer-menu-button
+          timeout: 20000
+      - tapOn:
+          id: app-drawer-menu-button
+      - tapOn: Profile
+      - assertVisible:
+          text: Profile
+          above:
+            text: ${output.resetEmail}

--- a/.maestro/flows/sign-in.yaml
+++ b/.maestro/flows/sign-in.yaml
@@ -1,4 +1,8 @@
 appId: ${MAESTRO_APP_ID}
+onFlowStart:
+  - runScript: ../api.js
+  # Make sign-in independent of reset-password leftover state.
+  - evalScript: ${output.api.updateUserPassword(MAESTRO_TEST_EMAIL, MAESTRO_TEST_PASSWORD)}
 ---
 # - runFlow:
 #     when:
@@ -8,12 +12,16 @@ appId: ${MAESTRO_APP_ID}
 - tapOn:
     text: Sign In
     index: -1
-- tapOn: Enter your email
-- inputText: ${MAESTRO_TEST_EMAIL}
-- tapOn: Enter your password
-- inputText: ${MAESTRO_TEST_PASSWORD}
 - tapOn:
-    point: 95%,30%
+    id: sign-in-email
+- eraseText
+- inputText: ${MAESTRO_TEST_EMAIL}
+- hideKeyboard
+- tapOn:
+    id: sign-in-password
+- eraseText
+- inputText: ${MAESTRO_TEST_PASSWORD}
+- hideKeyboard
 - tapOn:
     text: Sign In
     below: I forgot my password

--- a/components/AppHeader.tsx
+++ b/components/AppHeader.tsx
@@ -300,6 +300,8 @@ export default function AppHeader({
             onPress={drawerToggleCallback}
             className="relative"
             testID="app-drawer-menu-button"
+            accessible
+            accessibilityLabel="app-drawer-menu-button"
           >
             <Icon as={MenuIcon} className="size-6 text-foreground" />
 

--- a/views/SignInView.tsx
+++ b/views/SignInView.tsx
@@ -113,6 +113,7 @@ export default function SignInView() {
               <FormControl>
                 <Input
                   {...transformInputProps(field)}
+                  testID="sign-in-email"
                   mask
                   type="next"
                   autoCapitalize="none"
@@ -134,6 +135,7 @@ export default function SignInView() {
               <FormControl>
                 <Input
                   {...transformInputProps(field)}
+                  testID="sign-in-password"
                   onSubmitEditing={handleFormSubmit}
                   returnKeyType="done"
                   autoCapitalize="none"


### PR DESCRIPTION
What broke
The production Maestro job runs register, reset-password, and sign-in in that order. Android and iOS run that suite at the same time against the same Supabase project. Reset was changing test@langquest.org to a random password, then trying to put it back. The other phone's reset or sign-in often ran in the middle of that, so sign-in got "invalid login credentials". Reset itself also failed after a successful password change: the Success alert vanished before Maestro tapped OK, the app was already on Profile, and the hamburger's test id was missing from the accessibility tree once the sync badge sat on the icon. What this commit does
Reset now admin-creates a one-off confirmed user, resets that user, then deletes them. test@langquest.org is left alone. Sign-in still uses the shared account, but it admin-sets the known password at the start of the flow so a leftover dirty password cannot fail the login. Sign-in types into sign-in-email / sign-in-password instead of placeholders. The menu button is a single accessibility element so Maestro can find app-drawer-menu-button after login. If reset already shows the new user's email on Profile, it does not open the drawer.