### PR TITLE
refactor(maestro): remove unused same_password handler

### DIFF
--- a/.maestro/api.js
+++ b/.maestro/api.js
@@ -63,8 +63,7 @@ function getUserByEmail(email) {
 }
 
 function uniqueEmail(prefix) {
-  const tag =
-    Date.now().toString(36) + Math.random().toString(36).slice(2, 8);
+  const tag = Date.now().toString(36) + Math.random().toString(36).slice(2, 8);
   const safePrefix = String(prefix || 'maestro').replace(/[^a-z0-9]/gi, '');
   return safePrefix + '.' + tag + '@langquest.org';
 }

--- a/.maestro/api.js
+++ b/.maestro/api.js
@@ -79,17 +79,6 @@ function uniquePassword(prefix) {
   );
 }
 
-function isSamePasswordError(status, body) {
-  if (status !== 422 && status !== 400) {
-    return false;
-  }
-  const text = String(body || '');
-  return (
-    text.indexOf('same_password') !== -1 ||
-    text.indexOf('should be different from the old password') !== -1
-  );
-}
-
 function createConfirmedUser(email, password) {
   if (!email || typeof email !== 'string' || email.trim() === '') {
     throw new Error(
@@ -189,14 +178,6 @@ function updateUserPassword(email, newPassword) {
   console.log('Update password response body:', updateResponse.body);
 
   if (updateResponse.status !== 200) {
-    // GoTrue 422 same_password: the password is already the requested value.
-    // Parallel iOS/Android jobs used to fail here while fighting over one user.
-    if (isSamePasswordError(updateResponse.status, updateResponse.body)) {
-      console.log(
-        'Password already matches requested value; treating as success'
-      );
-      return user;
-    }
     throw new Error(
       'Failed to update password: ' +
         updateResponse.status +

--- a/.maestro/flows/reset-password.yaml
+++ b/.maestro/flows/reset-password.yaml
@@ -2,14 +2,13 @@ appId: ${MAESTRO_APP_ID}
 onFlowStart:
   - runScript: ../api.js
 onFlowComplete:
-  # Throwaway user — never share an account with sign-in.yaml or the other OS.
   - evalScript: ${output.api.deleteUserIfExists(output.resetEmail)}
 ---
 # Reset Password Test Flow
 # 1. Create a throwaway confirmed user (Android and iOS must not share one)
 # 2. Generate reset link via admin API
 # 3. Open reset link (deep link)
-# 4. Enter a random new password
+# 4. Enter a new password that differs from the throwaway's initial password
 # 5. Verify the user is logged in
 # 6. Delete the throwaway user
 #
@@ -53,7 +52,7 @@ onFlowComplete:
     point: 95%,30%
 - tapOn: Update Password
 
-# Success alert can auto-dismiss after the recovery session becomes a normal login.
+# Success alert can auto-dismiss after the recovery session becomes a login.
 - runFlow:
     when:
       visible: Success

--- a/.maestro/flows/sign-in.yaml
+++ b/.maestro/flows/sign-in.yaml
@@ -2,13 +2,11 @@ appId: ${MAESTRO_APP_ID}
 onFlowStart:
   - runScript: ../api.js
 onFlowComplete:
-  # Throwaway user — never share MAESTRO_TEST_EMAIL across iOS/Android/jobs.
   # create-records.yaml sets skipSignInCleanup so it can keep using this session.
   - evalScript: ${output.skipSignInCleanup !== true && output.api.deleteUserIfExists(output.signInEmail)}
 ---
-# Sign in with a throwaway user. iOS and Android Maestro jobs run in parallel
-# against the same Supabase project; sharing test@langquest.org caused
-# "Invalid login credentials" and GoTrue same_password errors.
+# iOS and Android Maestro jobs run in parallel against the same Supabase
+# project. Each run gets its own user so they cannot fight over one password.
 
 # - runFlow:
 #     when:


### PR DESCRIPTION
## Summary
- Drop the unused GoTrue `same_password` workaround from Maestro's admin API helper. Throwaway users already isolate iOS and Android, so no flow calls `updateUserPassword` anymore.
- Trim related comments in the sign-in and reset-password flows.
- Includes a follow-up format pass on the Maestro helper and email templates.

Fixes LQ-113's leftover dead path on `dev`; the throwaway-user isolation stays.

## Test plan
- [ ] Confirm preview Maestro still runs register → reset-password → sign-in on iOS and Android in parallel without sharing `test@langquest.org`
- [ ] Confirm no Maestro flow calls `updateUserPassword`
- [ ] Spot-check email templates still render (format-only whitespace)


Made with [Cursor](https://cursor.com)