### PR TITLE
Update statement timeout to be non-local

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -218,7 +218,7 @@ export default ({ config }: ConfigContext): ExpoConfig =>
     owner: 'eten-genesis',
     name: getAppName(appVariant),
     slug: 'langquest',
-    version: '2.2.5',
+    version: '2.2.6',
     orientation: 'portrait',
     icon: iconLight,
     scheme: getScheme(appVariant),

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "langquest",
   "main": "expo-router/entry",
-  "version": "2.2.5",
+  "version": "2.2.6",
   "scripts": {
     "start": "expo start --dev-client",
     "start:offline:android": "npm run start -- --localhost --android",

--- a/supabase/migrations/20260826120000_add_audio_uploaded_at_to_acl.sql
+++ b/supabase/migrations/20260826120000_add_audio_uploaded_at_to_acl.sql
@@ -45,9 +45,10 @@
 -- ============================================================================
 
 -- Index build + backfills exceed the default statement timeout at current
--- table sizes (~800k acl rows). SET LOCAL scopes this to the migration's
--- transaction only.
-set local statement_timeout = '1h';
+-- table sizes (~800k acl rows). Session-level SET (not SET LOCAL): the CLI
+-- applies migration statements outside an explicit transaction block, where
+-- SET LOCAL warns and does nothing. Reset at the end of the file.
+set statement_timeout = '1h';
 
 -- ----------------------------------------------------------------------------
 -- PART 1: Column + index
@@ -220,3 +221,5 @@ as $$
     'notes', 'Clients must be at least version 2.1 to sync. Version 2.5 adds asset_content_link.audio_uploaded_at (server-confirmed audio upload time).'
   );
 $$;
+
+reset statement_timeout;


### PR DESCRIPTION
Migration error occurred going into dev that SET LOCAL can only be used in transaction blocks. Updating the migration file to something that's worked in the past. Estimated time for longest transaction in this migration is 5-15 minutes given current indexes available and the ~700k records in both asset_content_link and storage.objects.