### PR TITLE
Stop re-uploading while syncing down (#928)

### DIFF
--- a/db/powersync/system.ts
+++ b/db/powersync/system.ts
@@ -369,7 +369,12 @@ export class System {
         },
         // Network store, not powersync.connected: storage transfers are plain
         // HTTPS and can proceed while the sync websocket is still connecting.
-        isOnline: () => useNetworkStore.getState().isConnected
+        isOnline: () => useNetworkStore.getState().isConnected,
+        // While the sync stream is applying server changes, local
+        // audio_uploaded_at values lag the server; pause uploads so we don't
+        // re-send files whose confirmations are still on the wire.
+        isSyncingDown: () =>
+          this.powersync.currentStatus.dataFlowStatus.downloading ?? false
       });
       this.audioDownloader = new AudioDownloader({
         db: this.db,
@@ -1294,6 +1299,21 @@ export class System {
 
       this.audioUploader?.start();
       this.audioDownloader?.start();
+
+      // The uploader skips transfers while the sync stream is downloading
+      // (stale local confirmations). If the stream's last batch touched no
+      // watched rows, nothing re-schedules a pass until the periodic tick —
+      // so nudge (backoff-preserving) whenever downloading settles.
+      let wasSyncingDown = false;
+      this.powersync.registerListener({
+        statusChanged: (status) => {
+          const downloading = status.dataFlowStatus.downloading ?? false;
+          if (wasSyncingDown && !downloading) {
+            this.audioUploader?.nudge();
+          }
+          wasSyncingDown = downloading;
+        }
+      });
 
       // Safety net: re-derive work lists when the app returns to the
       // foreground (backgrounded uploads/downloads may have been suspended

--- a/services/attachments/AudioUploader.ts
+++ b/services/attachments/AudioUploader.ts
@@ -21,6 +21,11 @@
  *
  * Failures are never terminal. Each file gets an in-memory exponential
  * backoff; nothing here ever touches a local file.
+ *
+ * Transfers pause while PowerSync is downloading sync data (isSyncingDown):
+ * until the stream settles, locally-null audio_uploaded_at values may just be
+ * confirmations that haven't arrived yet, and uploading against them wastes
+ * bandwidth re-sending files the server already has.
  */
 
 import type * as drizzleSchema from '@/db/drizzleSchema';
@@ -88,6 +93,14 @@ export interface AudioUploaderOptions {
   hasSession: () => Promise<boolean>;
   /** No transfer attempts while offline (work list is still derived). */
   isOnline: () => boolean;
+  /**
+   * No transfer attempts while PowerSync is actively downloading sync data:
+   * the local audio_uploaded_at values are known-stale until the stream
+   * settles, so uploading against them re-uploads files the server already
+   * confirmed (harmless but wasteful — after a server-side backfill this
+   * could be thousands of redundant uploads on a metered connection).
+   */
+  isSyncingDown: () => boolean;
 }
 
 export class AudioUploader {
@@ -134,6 +147,16 @@ export class AudioUploader {
       state.nextAttemptAt = 0;
     }
     this.schedule(0);
+  }
+
+  /**
+   * Request a pass WITHOUT clearing backoff waits (unlike trigger()). Used
+   * when the sync download stream settles: a drain skipped by isSyncingDown
+   * may have no follow-up event until the periodic tick, but confirmation
+   * grace periods and failure backoffs must survive.
+   */
+  nudge(): void {
+    this.schedule();
   }
 
   getStatus(): AudioUploaderStatus {
@@ -233,6 +256,13 @@ export class AudioUploader {
     // Offline: report honest pending counts but attempt nothing — backoff
     // state stays untouched, and reconnect trigger()s an immediate pass.
     if (!this.options.isOnline()) {
+      this.publishWorkStatus(workList, 0);
+      return;
+    }
+
+    // Sync stream busy: local confirmations are stale, so wait it out.
+    // system.ts nudge()s a pass when the download stream settles.
+    if (this.options.isSyncingDown()) {
       this.publishWorkStatus(workList, 0);
       return;
     }


### PR DESCRIPTION
Once updated, the client will try to start uploading all the files they already uploaded because the server-side update to the new audio_uploaded_at field hasn't synced down to the user's device. This update prevents file uploads while records are actively being synced down. Once records are stabilized, the guard could theoretically be removed if it's slowing things down.