### PR TITLE
Prevent runaway train of uploading (#930)

### DIFF
--- a/services/attachments/AudioDownloader.ts
+++ b/services/attachments/AudioDownloader.ts
@@ -222,8 +222,23 @@ export class AudioDownloader {
     let succeeded = 0;
     const queue = [...ready];
     let active = 0;
+    let pausedMidBatch = false;
 
     const runNext = async (): Promise<void> => {
+      // The pass-start offline guard can't protect a batch already in
+      // flight. Re-check before pulling each file so going offline mid-batch
+      // stops the pass instead of burning through thousands of failing
+      // attempts; reconnect trigger()s a fresh pass.
+      if (!this.options.isOnline()) {
+        if (!pausedMidBatch && queue.length > 0) {
+          pausedMidBatch = true;
+          console.log(
+            `[AudioDownloader] Pausing batch with ${queue.length} file(s) unstarted (offline)`
+          );
+        }
+        queue.length = 0;
+        return;
+      }
       const filename = queue.shift();
       if (filename === undefined) return;
       active++;

--- a/services/attachments/AudioUploader.ts
+++ b/services/attachments/AudioUploader.ts
@@ -25,7 +25,9 @@
  * Transfers pause while PowerSync is downloading sync data (isSyncingDown):
  * until the stream settles, locally-null audio_uploaded_at values may just be
  * confirmations that haven't arrived yet, and uploading against them wastes
- * bandwidth re-sending files the server already has.
+ * bandwidth re-sending files the server already has. The pause (and the
+ * offline check) applies both at pass start and before each file within a
+ * batch, so even a huge in-flight batch stops within CONCURRENCY files.
  */
 
 import type * as drizzleSchema from '@/db/drizzleSchema';
@@ -292,8 +294,25 @@ export class AudioUploader {
     let succeeded = 0;
     const queue = [...ready];
     let active = 0;
+    let pausedMidBatch = false;
 
     const runNext = async (): Promise<void> => {
+      // The pass-start guards can't protect a batch already in flight, and a
+      // batch can be huge (tens of thousands of stale rows right after an app
+      // upgrade). Re-check before pulling each file: workers stop pulling,
+      // the (≤ CONCURRENCY) in-flight uploads finish, and the pass ends
+      // early. Whatever ends the pause (settle nudge, reconnect trigger, row
+      // watcher) re-derives a fresh work list.
+      if (!this.options.isOnline() || this.options.isSyncingDown()) {
+        if (!pausedMidBatch && queue.length > 0) {
+          pausedMidBatch = true;
+          console.log(
+            `[AudioUploader] Pausing batch with ${queue.length} file(s) unstarted (offline or sync stream active)`
+          );
+        }
+        queue.length = 0;
+        return;
+      }
       const filename = queue.shift();
       if (filename === undefined) return;
       active++;


### PR DESCRIPTION
- whenever a pass runs, it checks for a sync-down in progress (and whether it's gone offline) — both at the start of the pass and again before each file is pulled, so even a huge batch already running stops within a few files 
- if something is coming down, the pass just ends — queue cleared, in-flight uploads finish, worker goes idle (nothing sits around waiting) 
- once the sync-down finishes, the powersync statusChanged listener in system.ts notices downloading flipped off and hits nudge(), which requests a fresh pass — the work list is rebuilt from the db, so anything the sync just confirmed drops off before uploading resumes